### PR TITLE
Fix use of heap after dealloc

### DIFF
--- a/Button.h
+++ b/Button.h
@@ -67,8 +67,6 @@ protected:
 
     //Stores the bound function
     std::function<void()> func;
-    std::function<void(void*)> funcWArg;
-    void* arg = nullptr;
 
     //Saves the index of the keyboard key this button is bound to
     int key;

--- a/Checkbox.cpp
+++ b/Checkbox.cpp
@@ -2,61 +2,61 @@
 #include "ToggleButton.h"
 #include "Label.h"
 
-Checkbox::Checkbox(SDL_Renderer* r, int x, int y, int Height, std::string text, int textSize, std::function<void(bool)> f, int keybind) : Checkbox(r, x, y, Height, text, textSize, top_left, f, keybind) {
-}
-
-Checkbox::Checkbox(SDL_Renderer* r, int x, int y, int Height, std::string text, int textSize, [[maybe_unused]]Anchor anchor, std::function<void(bool)> f, int keybind) {
-	toggleButton = std::make_unique<ToggleButton>(r, x, y, Height, Height, "Drawable/Checkbox/Ticked Checkbox", "Drawable/Checkbox/Empty Checkbox", f, keybind);
-	label = std::make_unique<Label>(r, text, textSize, x + int(Height * (1 + 0.1)), y);
+Checkbox::Checkbox(SDL_Renderer* r, int x, int y, int Height, std::string text, int textSize, [[maybe_unused]]Anchor anchor, std::function<void(bool)> f, int keybind) :
+    toggleButton(r, x, y, Height, Height, "Drawable/Checkbox/Ticked Checkbox", "Drawable/Checkbox/Empty Checkbox", f, keybind),
+    label(r, text, textSize, x + int(Height * (1 + 0.1)), y)
+{
+//	toggleButton = std::make_unique<ToggleButton>(r, x, y, Height, Height, "Drawable/Checkbox/Ticked Checkbox", "Drawable/Checkbox/Empty Checkbox", f, keybind);
+//	label = std::make_unique<Label>(r, text, textSize, x + int(Height * (1 + 0.1)), y);
 }
 
 void Checkbox::pDraw() {
-	toggleButton->Draw();
-	label->Draw();
+	toggleButton.Draw();
+	label.Draw();
 }
 
 void Checkbox::HandleInput(const SDL_Event& ev) {
-	toggleButton->HandleInput(ev);
+	toggleButton.HandleInput(ev);
 }
 
 void Checkbox::ChangePosition(int x, int y, int Height) {
-	toggleButton->ChangePosition(x, y, Height, Height);
-	label->ChangePosition(x, y);
+	toggleButton.ChangePosition(x, y, Height, Height);
+	label.ChangePosition(x, y);
 }
 
 void Checkbox::ChangeFunctionBinding(std::function<void(bool)> f) {
-	toggleButton->ChangeFunctionBinding(f);
+	toggleButton.ChangeFunctionBinding(f);
 }
 
 void Checkbox::ChangeKeybind(int keybind) {
-	toggleButton->ChangeKeybind(keybind);
+	toggleButton.ChangeKeybind(keybind);
 }
 
 void Checkbox::ChangeText(std::string text) {
-	label->ChangeText(text);
+	label.ChangeText(text);
 }
 
 void Checkbox::ChangeTextSize(int size) {
-	label->ChangeTextSize(size);
+	label.ChangeTextSize(size);
 }
 
 void Checkbox::ChangeValue(bool val) {
-	toggleButton->ChangeValue(val);
+	toggleButton.ChangeValue(val);
 }
 
 bool Checkbox::GetValue() {
-	return toggleButton->GetValue();
+	return toggleButton.GetValue();
 }
 
 void Checkbox::Playsound() {
-	toggleButton->Playsound();
+	toggleButton.Playsound();
 }
 
 void Checkbox::CallBoundFunction() {
-	toggleButton->CallBoundFunction();
+	toggleButton.CallBoundFunction();
 }
 
 void Checkbox::SetActive(bool state) {
 	InputDrawable::SetActive(state);
-	toggleButton->SetActive(state);
+	toggleButton.SetActive(state);
 }

--- a/Checkbox.h
+++ b/Checkbox.h
@@ -2,20 +2,20 @@
 #define CHECKBOX_H
 
 #pragma once
+#include "Drawable.h"
+#include "Label.h"
+#include "ToggleButton.h"
+
 #include <SDL.h>
+
 #include <string>
 #include <functional>
 #include <memory>
-#include "Drawable.h"
-
-class Label;
-class ToggleButton;
 
 class Checkbox : public InputDrawable {
 public:
 	//Constructor
-	Checkbox(SDL_Renderer* r, int x, int y, int Height, std::string text, int textSize, std::function<void(bool)> f = nullptr, int keybind = 0);
-	Checkbox(SDL_Renderer* r, int x, int y, int Height, std::string text, int textSize, Anchor anchor, std::function<void(bool)> f = nullptr, int keybind = 0);
+	Checkbox(SDL_Renderer* r, int x, int y, int Height, std::string text, int textSize, Anchor anchor, std::function<void(bool)> f, int keybind = 0);
 
 	//Destructor
 	~Checkbox() = default;
@@ -58,8 +58,10 @@ protected:
 	void pDraw();
 
 	//The Drawables that make up this Drawable
-	std::unique_ptr<ToggleButton> toggleButton;
-	std::unique_ptr<Label> label;
+	//std::unique_ptr<ToggleButton> toggleButton;
+	//std::unique_ptr<Label> label;
+        ToggleButton toggleButton;
+        Label label;
 };
 
 #endif

--- a/MainProg.cpp
+++ b/MainProg.cpp
@@ -2,7 +2,5 @@
 #include "MainWindow.h"
 
 int main() {
-    MainWindow wind;
-    wind.MainLoop();
-    return 0;
+    MainWindow::Instance().MainLoop();
 }

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -10,10 +10,14 @@
 #include <SDL_ttf.h>
 #include <SDL_mixer.h>
 
+#include <functional>
+#include <utility>
+#include <vector>
+
 class MainWindow {
 public:
-    //Constructor
-    MainWindow();
+    // Singleton instance interface
+    static MainWindow& Instance();
 
     //The Main loop of the window
     void MainLoop();
@@ -34,6 +38,7 @@ public:
     void ChangeScreen(std::unique_ptr<Screen> NewScreen);
 
 public:
+    // Note that the order of the SDL context instances is important
     SDL_Init_ctx sdl_init_ctx;
     SDL_Window_ctx window; //The game's main window
     SDL_Renderer_ctx renderer; //The window's renderer
@@ -45,7 +50,7 @@ public:
 public:
     bool KEYS[322];  // 322 is the number of SDLK_DOWN events
 
-    int quit;
+    bool quit = false;
 
     //Used to store the window's width and Height
     int Width;
@@ -53,5 +58,16 @@ public:
 
     //Stores a pointer to the active screen
     std::unique_ptr<Screen> scr;
+
+    template<class Event>
+    void AddEvent(Event&& ev) {
+        event_queue.emplace_back(std::forward<Event>(ev));
+    }
+private:
+    //Constructor
+    MainWindow();
+
+    std::vector<std::function<void()>> event_queue;
 };
+
 #endif

--- a/Slider.h
+++ b/Slider.h
@@ -9,8 +9,8 @@
 class Slider : public InputDrawable {
 public:
 	//Constructor, initializes the values
-	Slider(SDL_Renderer* r, int x, int y, int Width, int Height, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = nullptr);
-	Slider(SDL_Renderer* r, int x, int y, int Width, int Height, Anchor anchor, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = nullptr);
+	Slider(SDL_Renderer* r, int x, int y, int Width, int Height, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
+	Slider(SDL_Renderer* r, int x, int y, int Width, int Height, Anchor anchor, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
 
 	//Destructor, frees up the memory
 	~Slider();
@@ -23,9 +23,6 @@ public:
 
 	//Change the slider's position on the screen
 	void ChangePosition(int x, int y, int Width, int Height);
-
-	//Called when the value of the slider changes
-	std::function<void()> onSliderValueChanged;
 
 	//Holds the slider's values
 	struct {
@@ -56,5 +53,9 @@ protected:
 
 	//Whether the mouse has been pressed over the Marker
 	bool bmousepressed;
+
+private:
+	//Called when the value of the slider changes
+	std::function<void()> onSliderValueChanged;
 };
 #endif


### PR DESCRIPTION
Buttons now place their bound functions in an event queue in `MainWindow` to prevent the bound functions to destroy a button still receiving events. `MainWindow` will now process all events collected by its `Screen` and all the `Screen`'s children afterwards.

Added some logging to `std:err`, mainly around `Button`s.

This should fix issue #5