### PR TITLE
Use SDL_Renderer_ctx& instead of SDL_Renderer*

### DIFF
--- a/Button.cpp
+++ b/Button.cpp
@@ -82,12 +82,6 @@ void log(Button* This, const char* txt) {
 Button::~Button() {
     std::cerr << "Button::~Button\t" << static_cast<void*>(this) << std::endl;
     deads.emplace(this);
-    //Free up the memory
-    SDL_DestroyTexture(texture);
-
-    if (text != nullptr) {
-        SDL_DestroyTexture(text);
-    }
 
     Mix_FreeChunk(music);
 }
@@ -150,14 +144,6 @@ bool Button::CheckIfMouseInRect(const SDL_Rect& rect, const SDL_MouseButtonEvent
 void Button::ChangeImage(std::string image) {
     //Saving the new image path
     auto imagePath = image + ".png";
-
-    //Destroy the texture if it already exists
-    if (texture != nullptr) {
-        SDL_DestroyTexture(texture);
-    }
-    if (this->text != nullptr) {
-        SDL_DestroyTexture(this->text);
-    }
 
     //Load the button texture
     texture = SDL_Texture_ctx::IMG_Load(RendererReference, imagePath);

--- a/Button.cpp
+++ b/Button.cpp
@@ -8,17 +8,14 @@
 
 std::unordered_set<Button*> deads; // Only used for debugging
 
-Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string image, std::function<void()> f, int keybind) : Button(r, x, y, Width, Height, image, top_left, f, keybind) {
+Button::Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string image, std::function<void()> f, int keybind) : Button(r, x, y, Width, Height, image, top_left, f, keybind) {
 }
 
-Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string image, std::function<void(void*)> f, void* arg, int keybind) : Button(r, x, y, Width, Height, image, top_left, f, arg, keybind) {
+Button::Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string image, std::function<void(void*)> f, void* arg, int keybind) : Button(r, x, y, Width, Height, image, top_left, f, arg, keybind) {
 }
 
-Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string image, Anchor anchor, std::function<void()> f, int keybind) : InputDrawable(anchor) {
+Button::Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string image, Anchor anchor, std::function<void()> f, int keybind) : InputDrawable(anchor), RendererReference(r) {
     deads.erase(this); // if a previous Button had the same address, remove it from the dead Buttons
-
-    //Saving the renderer's reference
-    RendererReference = r;
 
     //Sets the default value for the button's state
     bHovered = false;
@@ -39,21 +36,18 @@ Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string
     music = Mix_LoadWAV("Sounds/ButtonClick.mp3");
 }
 
-Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string image, Anchor anchor, std::function<void(void*)> f, void* arg, int keybind) : Button(r, x, y, Width, Height, image, anchor, nullptr, keybind) {
+Button::Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string image, Anchor anchor, std::function<void(void*)> f, void* arg, int keybind) : Button(r, x, y, Width, Height, image, anchor, nullptr, keybind) {
     //Saving the bound function
     ChangeFunctionBinding(f, arg);
 }
 
-Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string text, int textSize, std::function<void()> f, int keybind) : Button(r, x, y, Width, Height, text, textSize, top_left, f, keybind) {
+Button::Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string text, int textSize, std::function<void()> f, int keybind) : Button(r, x, y, Width, Height, text, textSize, top_left, f, keybind) {
 }
 
-Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string text, int textSize, std::function<void(void*)> f, void* arg, int keybind) : Button(r, x, y, Width, Height, text, textSize, top_left, f, arg, keybind) {
+Button::Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string text, int textSize, std::function<void(void*)> f, void* arg, int keybind) : Button(r, x, y, Width, Height, text, textSize, top_left, f, arg, keybind) {
 }
 
-Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void()> f, int keybind) : InputDrawable(anchor) {
-    //Saving the renderer's reference
-    RendererReference = r;
-
+Button::Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void()> f, int keybind) : InputDrawable(anchor), RendererReference(r) {
     //Sets the default value for the button's state
     bHovered = false;
 
@@ -73,7 +67,7 @@ Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string
     music = Mix_LoadWAV("Sounds/ButtonClick.mp3");
 }
 
-Button::Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void(void*)> f, void* arg, [[maybe_unused]] int keybind) : Button(r, x, y, Width, Height, text, textSize, anchor) {
+Button::Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void(void*)> f, void* arg, [[maybe_unused]] int keybind) : Button(r, x, y, Width, Height, text, textSize, anchor) {
     //Saving the bound function
     ChangeFunctionBinding(f, arg);
 }

--- a/Button.cpp
+++ b/Button.cpp
@@ -168,7 +168,7 @@ void Button::ChangeText(std::string textstr, int textSize){
     texture = SDL_Texture_ctx::IMG_Load(RendererReference, "Drawable/Button/Button.png");
 
     //Loading the font from the file
-    TTF_Font* font = TTF_OpenFont(GLOBAL_FONT, textSize);
+    TTF_Font_ctx font(textSize);
 
     //Convert the text to a surface
     SDL_Surface_ctx textSur(TTF_RenderText_Blended(font, textstr.c_str(), SDL_Color{.r = 255, .g = 255, .b = 255, .a = 0}));
@@ -180,9 +180,6 @@ void Button::ChangeText(std::string textstr, int textSize){
                         .y = draw_rect.y + text_y,
                         .w = (text_x > 0 ? textSur->w : int(draw_rect.w * 0.8)),
                         .h = textSur->h };
-
-    //Delete the font
-    TTF_CloseFont(font);
 
     bHovered = false;
 }

--- a/Button.cpp
+++ b/Button.cpp
@@ -160,34 +160,21 @@ void Button::ChangeImage(std::string image) {
     }
 
     //Load the button texture
-    SDL_Surface* img = IMG_Load(imagePath.c_str());
-    texture = SDL_CreateTextureFromSurface(RendererReference, img);
-    SDL_FreeSurface(img);
+    SDL_Surface_ctx img(IMG_Load(imagePath.c_str()));
+    texture = SDL_Texture_ctx(RendererReference, img);
 }
 
-void Button::ChangeText(std::string text, int textSize){
-    //Destroy the texture if it already exists
-    if (texture != nullptr) {
-        SDL_DestroyTexture(texture);
-    }
-    if (this->text != nullptr) {
-        SDL_DestroyTexture(this->text);
-        this->text = nullptr;
-    }
-
+void Button::ChangeText(std::string textstr, int textSize){
     //Load the button background
-    SDL_Surface* bg = IMG_Load("Drawable/Button/Button.png");
-    texture = SDL_CreateTextureFromSurface(RendererReference, bg);
-
-    //Free the background surface
-    SDL_FreeSurface(bg);
+    SDL_Surface_ctx bg(IMG_Load("Drawable/Button/Button.png"));
+    texture = SDL_Texture_ctx(RendererReference, bg);
 
     //Loading the font from the file
     TTF_Font* font = TTF_OpenFont(GLOBAL_FONT, textSize);
 
     //Convert the text to a surface
-    SDL_Surface* textSur = TTF_RenderText_Blended(font, text.c_str(), SDL_Color{.r = 255, .g = 255, .b = 255, .a = 0});
-    this->text = SDL_CreateTextureFromSurface(RendererReference, textSur);
+    SDL_Surface_ctx textSur(TTF_RenderText_Blended(font, textstr.c_str(), SDL_Color{.r = 255, .g = 255, .b = 255, .a = 0}));
+    text = SDL_Texture_ctx(RendererReference, textSur);
 
     int text_x = (draw_rect.w - textSur->w) / 2;
     int text_y = (draw_rect.h - textSur->h) / 3;
@@ -195,9 +182,6 @@ void Button::ChangeText(std::string text, int textSize){
                         .y = draw_rect.y + text_y,
                         .w = (text_x > 0 ? textSur->w : int(draw_rect.w * 0.8)),
                         .h = textSur->h };
-
-    //Free the surface
-    SDL_FreeSurface(textSur);
 
     //Delete the font
     TTF_CloseFont(font);

--- a/Button.cpp
+++ b/Button.cpp
@@ -160,14 +160,12 @@ void Button::ChangeImage(std::string image) {
     }
 
     //Load the button texture
-    SDL_Surface_ctx img(IMG_Load(imagePath.c_str()));
-    texture = SDL_Texture_ctx(RendererReference, img);
+    texture = SDL_Texture_ctx::IMG_Load(RendererReference, imagePath);
 }
 
 void Button::ChangeText(std::string textstr, int textSize){
     //Load the button background
-    SDL_Surface_ctx bg(IMG_Load("Drawable/Button/Button.png"));
-    texture = SDL_Texture_ctx(RendererReference, bg);
+    texture = SDL_Texture_ctx::IMG_Load(RendererReference, "Drawable/Button/Button.png");
 
     //Loading the font from the file
     TTF_Font* font = TTF_OpenFont(GLOBAL_FONT, textSize);

--- a/Button.h
+++ b/Button.h
@@ -2,24 +2,28 @@
 #define BUTTON_H
 
 #pragma once
+#include "Drawable.h"
+
+#include "SDL_ctx.h"
+
 #include <SDL.h>
-#include <string>
-#include <functional>
 #include <SDL_image.h>
 #include <SDL_mixer.h>
-#include "Drawable.h"
+
+#include <functional>
+#include <string>
 
 class Button : public InputDrawable {
 public:
     //Constructors
-    Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string image, std::function<void()> f = nullptr, int keybind = 0);
-    Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string image, std::function<void(void*)> f, void* arg, int keybind = 0);
-    Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string image, Anchor anchor, std::function<void()> f = nullptr, int keybind = 0);
-    Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string image, Anchor anchor, std::function<void(void*)> f, void* arg, int keybind = 0);
-    Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string text, int textSize, std::function<void()> f = nullptr, int keybind = 0);
-    Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string text, int textSize, std::function<void(void*)> f, void* arg, int keybind = 0);
-    Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void()> f = nullptr, int keybind = 0);
-    Button(SDL_Renderer* r, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void(void*)> f, void* arg, int keybind = 0);
+    Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string image, std::function<void()> f = nullptr, int keybind = 0);
+    Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string image, std::function<void(void*)> f, void* arg, int keybind = 0);
+    Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string image, Anchor anchor, std::function<void()> f = nullptr, int keybind = 0);
+    Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string image, Anchor anchor, std::function<void(void*)> f, void* arg, int keybind = 0);
+    Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string text, int textSize, std::function<void()> f = nullptr, int keybind = 0);
+    Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string text, int textSize, std::function<void(void*)> f, void* arg, int keybind = 0);
+    Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void()> f = nullptr, int keybind = 0);
+    Button(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void(void*)> f, void* arg, int keybind = 0);
 
     //Destructor
     ~Button();
@@ -76,7 +80,7 @@ protected:
     SDL_Rect text_draw_rect;
 
     //Reference the the screen's renderer
-    SDL_Renderer* RendererReference;
+    RendererRef RendererReference;
 
     //Reference to the button's texture
     SDL_Texture* texture = nullptr;

--- a/Button.h
+++ b/Button.h
@@ -83,8 +83,8 @@ protected:
     RendererRef RendererReference;
 
     //Reference to the button's texture
-    SDL_Texture* texture = nullptr;
-    SDL_Texture* text = nullptr;
+    SDL_Texture_ctx texture;
+    SDL_Texture_ctx text;
 
     //The button's onClick sound
     Mix_Chunk* music = nullptr;

--- a/Checkbox.cpp
+++ b/Checkbox.cpp
@@ -2,7 +2,7 @@
 #include "ToggleButton.h"
 #include "Label.h"
 
-Checkbox::Checkbox(SDL_Renderer* r, int x, int y, int Height, std::string text, int textSize, [[maybe_unused]]Anchor anchor, std::function<void(bool)> f, int keybind) :
+Checkbox::Checkbox(SDL_Renderer_ctx& r, int x, int y, int Height, std::string text, int textSize, [[maybe_unused]]Anchor anchor, std::function<void(bool)> f, int keybind) :
     toggleButton(r, x, y, Height, Height, "Drawable/Checkbox/Ticked Checkbox", "Drawable/Checkbox/Empty Checkbox", f, keybind),
     label(r, text, textSize, x + int(Height * (1 + 0.1)), y)
 {

--- a/Checkbox.h
+++ b/Checkbox.h
@@ -15,7 +15,7 @@
 class Checkbox : public InputDrawable {
 public:
 	//Constructor
-	Checkbox(SDL_Renderer* r, int x, int y, int Height, std::string text, int textSize, Anchor anchor, std::function<void(bool)> f, int keybind = 0);
+	Checkbox(SDL_Renderer_ctx& r, int x, int y, int Height, std::string text, int textSize, Anchor anchor, std::function<void(bool)> f, int keybind = 0);
 
 	//Destructor
 	~Checkbox() = default;

--- a/CountrySelection.cpp
+++ b/CountrySelection.cpp
@@ -7,7 +7,7 @@
 #include "PlayerController.h"
 #include "UI.h"
 
-CountrySelection::CountrySelection(SDL_Renderer* r, std::function<void()> UnpauseF, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r, UnpauseF, fpl) {
+CountrySelection::CountrySelection(SDL_Renderer_ctx& r, std::function<void()> UnpauseF, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r, UnpauseF, fpl) {
 	SetupBg("Backgrounds/CountrySelection.png");
         auto [Width, Height] = GetWindowDimensions();
 

--- a/CreditScreen.cpp
+++ b/CreditScreen.cpp
@@ -4,7 +4,7 @@
 #include "Label.h"
 #include "MainWindow.h"
 
-CreditScreen::CreditScreen(SDL_Renderer* r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : BackScreen(r, fp, fpl) {
+CreditScreen::CreditScreen(SDL_Renderer_ctx& r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : BackScreen(r, fp, fpl) {
 	SetupBg("Backgrounds/OldMenu.png");
 
 	int fontSize = 40;

--- a/CreditScreen.h
+++ b/CreditScreen.h
@@ -2,5 +2,5 @@
 
 class CreditScreen : public Screen {
 public:
-	CreditScreen(SDL_Renderer* r, int Width, int Height);
+	CreditScreen(SDL_Renderer_ctx& r, int Width, int Height);
 };

--- a/DiplomacyScreen.cpp
+++ b/DiplomacyScreen.cpp
@@ -6,10 +6,10 @@
 #include "MainWindow.h"
 #include "PlayerController.h"
 
-DiplomacyScreen::DiplomacyScreen(SDL_Renderer* r, PlayerController* PC) : DiplomacyScreen(r, PC, PC->player_tag) {
+DiplomacyScreen::DiplomacyScreen(SDL_Renderer_ctx& r, PlayerController* PC) : DiplomacyScreen(r, PC, PC->player_tag) {
 }
 
-DiplomacyScreen::DiplomacyScreen(SDL_Renderer* r, PlayerController* PC, std::string targetTag) : Screen(r) {
+DiplomacyScreen::DiplomacyScreen(SDL_Renderer_ctx& r, PlayerController* PC, std::string targetTag) : Screen(r) {
 	SetupBg("Backgrounds/Industry.png");
 
         auto [Width, Height] = GetWindowDimensions();
@@ -39,7 +39,7 @@ DiplomacyScreen::DiplomacyScreen(SDL_Renderer* r, PlayerController* PC, std::str
 	UpdateAllianceState();
 }
 
-DiplomacyScreen::DiplomacyScreen(SDL_Renderer* r, PlayerController* PC, int index) : DiplomacyScreen(r, PC){
+DiplomacyScreen::DiplomacyScreen(SDL_Renderer_ctx& r, PlayerController* PC, int index) : DiplomacyScreen(r, PC){
 	SelectCountry((void*)((Uint64)index));
 }
 

--- a/Drawable.cpp
+++ b/Drawable.cpp
@@ -24,7 +24,7 @@ bool InputDrawable::GetActive() {
     return active;
 }
 
-void ApplyAnchor(SDL_Rect &rect, Anchor anchor) {
+void ApplyAnchor(SDL_Rect& rect, Anchor anchor) {
     switch (anchor) {
         case top_left:
             break;

--- a/Drawable.h
+++ b/Drawable.h
@@ -3,8 +3,6 @@
 
 #include <SDL.h>
 
-#define GLOBAL_FONT "Fonts/segoeui.ttf"
-
 enum Anchor {
 	top_left, top_right, bottom_left, bottom_right, center, center_top, center_bottom, center_left, center_right
 };

--- a/Drawable.h
+++ b/Drawable.h
@@ -37,6 +37,6 @@ protected:
 	bool active;
 };
 
-void ApplyAnchor(SDL_Rect &rect, Anchor anchor);
+void ApplyAnchor(SDL_Rect& rect, Anchor anchor);
 
 #endif

--- a/EconomyScreen.cpp
+++ b/EconomyScreen.cpp
@@ -5,7 +5,7 @@
 #include "Slider.h"
 #include "Label.h"
 
-EconomyScreen::EconomyScreen(SDL_Renderer* r, Country* Pl) : Screen(r), Player(Pl) {
+EconomyScreen::EconomyScreen(SDL_Renderer_ctx& r, Country* Pl) : Screen(r), Player(Pl) {
 	SetupBg("Backgrounds/Industry.png");
         auto [Width, Height] = GetWindowDimensions();
 

--- a/GameScreen.cpp
+++ b/GameScreen.cpp
@@ -8,6 +8,7 @@
 #include "Image.h"
 
 #include <cmath>
+#include <iostream>
 #include <memory>
 
 GameScreen::GameScreen(SDL_Renderer_ctx& r, const char* tag,  std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r) {

--- a/GameScreen.cpp
+++ b/GameScreen.cpp
@@ -10,7 +10,7 @@
 #include <cmath>
 #include <memory>
 
-GameScreen::GameScreen(SDL_Renderer* r, const char* tag,  std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r) {
+GameScreen::GameScreen(SDL_Renderer_ctx& r, const char* tag,  std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r) {
 	bHasBackground = true;
 	bIsPaused = false;
 	bZoom = true;

--- a/GameScreen.cpp
+++ b/GameScreen.cpp
@@ -180,18 +180,13 @@ void GameScreen::Handle_Input(SDL_Event& ev) {
                                 StateViewingScreen = std::make_unique<StatePreview>(renderer, state->State_ID - 1, state->State_Name, state->State_Controller, PC.get(), res, int(state->State_Population), fcs, close, change);
 			}
 
-			SDL_Surface* base = SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000);
-
-			SDL_Surface* Marker = IMG_Load("Icons/pin1.png");
+			SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000));
+			auto Marker = SDL_Surface_ctx::IMG_Load("Icons/pin1.png");
 
 			SDL_Rect strect = { .x = -x - 5384 + 7, .y = -y + 24, .w = 5616 * 3 , .h = 2160 };
-			SDL_BlitSurface(Marker, &strect, base, NULL);
+			SDL_BlitSurface(Marker, &strect, base, nullptr);
 
-			SDL_Texture* txt = SDL_CreateTextureFromSurface(renderer, base);
-			SDL_DestroyTexture(PC->overlay);
-			PC->overlay = txt;
-			SDL_FreeSurface(base);
-			SDL_FreeSurface(Marker);
+			PC->overlay = SDL_Texture_ctx(renderer, base);
 		}
 	}
 
@@ -327,10 +322,7 @@ void GameScreen::CloseActiveScreen(){
 void GameScreen::CloseScreenPreview(){
         StateViewingScreen.reset();
 
-	SDL_Surface* base = SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000);
+	SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000));
 
-	SDL_Texture* txt = SDL_CreateTextureFromSurface(renderer, base);
-	SDL_DestroyTexture(PC->overlay);
-	PC->overlay = txt;
-	SDL_FreeSurface(base);
+	PC->overlay = SDL_Texture_ctx(renderer, base);
 }

--- a/Image.cpp
+++ b/Image.cpp
@@ -7,21 +7,14 @@ Image::Image(SDL_Renderer_ctx& r, std::string img, int x, int y, int Width, int 
     imagepath = img;
 
     //Loading the image texture
-    SDL_Surface* image = IMG_Load(imagepath.c_str());
+    SDL_Surface_ctx image(IMG_Load(imagepath.c_str()));
 
-    texture = SDL_CreateTextureFromSurface(RendererReference, image);
-
-    SDL_FreeSurface(image);
-}
-
-Image::~Image(){
-    //Free up the memory
-    SDL_DestroyTexture(texture);
+    texture = SDL_Texture_ctx(RendererReference, image);
 }
 
 void Image::pDraw(){
     //Drawing the Image
-    SDL_RenderCopy(RendererReference, texture, NULL, &draw_rect);
+    SDL_RenderCopy(RendererReference, texture, nullptr, &draw_rect);
 }
 
 void Image::ChangeImage(std::string img){
@@ -42,8 +35,7 @@ void Image::Update(){
     SDL_DestroyTexture(texture);
 
     //Loading the image texture
-    SDL_Surface* image = IMG_Load(imagepath.c_str());
-    texture = SDL_CreateTextureFromSurface(RendererReference, image);
-    SDL_FreeSurface(image);
+    SDL_Surface_ctx image(IMG_Load(imagepath.c_str()));
+    texture = SDL_Texture_ctx(RendererReference, image);
     //SDL_SetTextureColorMod(texture, 255, 255, 255); //in order to change color of the state
 }

--- a/Image.cpp
+++ b/Image.cpp
@@ -1,10 +1,7 @@
 #include "Image.h"
 
-Image::Image(SDL_Renderer* r, std::string img, int x, int y, int Width, int Height, Anchor anchor) : Drawable(anchor) {
+Image::Image(SDL_Renderer_ctx& r, std::string img, int x, int y, int Width, int Height, Anchor anchor) : Drawable(anchor), RendererReference(r) {
     ChangePosition(x, y, Width, Height);
-    
-    //Saving the renderer's reference
-    RendererReference = r;
 
     //Saving the image path
     imagepath = img;

--- a/Image.cpp
+++ b/Image.cpp
@@ -1,15 +1,13 @@
 #include "Image.h"
 
-Image::Image(SDL_Renderer_ctx& r, std::string img, int x, int y, int Width, int Height, Anchor anchor) : Drawable(anchor), RendererReference(r) {
-    ChangePosition(x, y, Width, Height);
-
-    //Saving the image path
-    imagepath = img;
-
-    //Loading the image texture
-    SDL_Surface_ctx image(IMG_Load(imagepath.c_str()));
-
-    texture = SDL_Texture_ctx(RendererReference, image);
+Image::Image(SDL_Renderer_ctx& r, std::string img, int x, int y, int Width, int Height, Anchor anchor) :
+    Drawable(anchor),
+    RendererReference(r),
+    imagepath(img),
+    draw_rect{.x = x, .y = y, .w = Width, .h = Height},
+    texture(SDL_Texture_ctx::IMG_Load(RendererReference, imagepath))
+{
+    ApplyAnchor(draw_rect, dAnchor);
 }
 
 void Image::pDraw(){
@@ -19,7 +17,7 @@ void Image::pDraw(){
 
 void Image::ChangeImage(std::string img){
     //Saving the new image path
-    imagepath = img;
+    imagepath = std::move(img);
     Update();
 }
 
@@ -31,11 +29,7 @@ void Image::ChangePosition(int x, int y, int Width, int Height){
 }
 
 void Image::Update(){
-    //Free up the memory
-    SDL_DestroyTexture(texture);
-
     //Loading the image texture
-    SDL_Surface_ctx image(IMG_Load(imagepath.c_str()));
-    texture = SDL_Texture_ctx(RendererReference, image);
+    texture = SDL_Texture_ctx::IMG_Load(RendererReference, imagepath);
     //SDL_SetTextureColorMod(texture, 255, 255, 255); //in order to change color of the state
 }

--- a/Image.h
+++ b/Image.h
@@ -28,14 +28,14 @@ protected:
 	//Render the image on the screen
 	void pDraw();
 
+	//Reference the the screen's renderer
+	RendererRef RendererReference;
+
 	//Reference to the path of the image assigned to the button
 	std::string imagepath;
 
 	//Dimensions of the image
 	SDL_Rect draw_rect;
-
-	//Reference the the screen's renderer
-	RendererRef RendererReference;
 
 	//The texture containing the image surface
 	SDL_Texture_ctx texture;

--- a/Image.h
+++ b/Image.h
@@ -1,15 +1,19 @@
 #ifndef IMAGE_H
 #define IMAGE_H
 
+#include "Drawable.h"
+
+#include "SDL_ctx.h"
+
 #include <SDL.h>
 #include <SDL_image.h>
+
 #include <string>
-#include "Drawable.h"
 
 class Image : public Drawable {
 public:
 	//Constructors
-	Image(SDL_Renderer* r, std::string img, int x, int y, int Width, int Height, Anchor anchor = top_left);
+	Image(SDL_Renderer_ctx& r, std::string img, int x, int y, int Width, int Height, Anchor anchor = top_left);
 
 	//Destructor
 	~Image();
@@ -34,7 +38,7 @@ protected:
 	SDL_Rect draw_rect;
 
 	//Reference the the screen's renderer
-	SDL_Renderer* RendererReference;
+	RendererRef RendererReference;
 
 	//The texture containing the image surface
 	SDL_Texture* texture;

--- a/Image.h
+++ b/Image.h
@@ -15,9 +15,6 @@ public:
 	//Constructors
 	Image(SDL_Renderer_ctx& r, std::string img, int x, int y, int Width, int Height, Anchor anchor = top_left);
 
-	//Destructor
-	~Image();
-
 	//Change the image assigned to the button
 	void ChangeImage(std::string img);
 
@@ -41,7 +38,7 @@ protected:
 	RendererRef RendererReference;
 
 	//The texture containing the image surface
-	SDL_Texture* texture;
+	SDL_Texture_ctx texture;
 
 	friend class TextEntry;
 };

--- a/IndustryScreen.cpp
+++ b/IndustryScreen.cpp
@@ -2,7 +2,7 @@
 #include "MainWindow.h"
 #include "Label.h"
 
-IndustryScreen::IndustryScreen(SDL_Renderer* r, int Stockpile[30]) : Screen(r) {
+IndustryScreen::IndustryScreen(SDL_Renderer_ctx& r, int Stockpile[30]) : Screen(r) {
 	SetupBg("Backgrounds/Industry1.png");
         auto [Width, Height] = GetWindowDimensions();
 

--- a/Label.cpp
+++ b/Label.cpp
@@ -1,21 +1,18 @@
 #include "Label.h"
 #include "MainWindow.h"
 
-Label::Label(SDL_Renderer* r, std::string Text, int size, int x, int y, Uint8 red, Uint8 green, Uint8 blue) : Label(r, Text, size, x, y, 300, top_left, red, green, blue) {
+Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, Uint8 red, Uint8 green, Uint8 blue) : Label(r, Text, size, x, y, 300, top_left, red, green, blue) {
 }
 
-Label::Label(SDL_Renderer* r, std::string Text, int size, int x, int y, Anchor anchor, Uint8 red, Uint8 green, Uint8 blue) : Label(r, Text, size, x, y, 300, anchor, red, green, blue) {
+Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, Anchor anchor, Uint8 red, Uint8 green, Uint8 blue) : Label(r, Text, size, x, y, 300, anchor, red, green, blue) {
 }
 
-Label::Label(SDL_Renderer* r, std::string Text, int size, int x, int y, int xlim, Uint8 red, Uint8 green, Uint8 blue) : Label(r, Text, size, x, y, xlim, top_left, red, green, blue) {
+Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xlim, Uint8 red, Uint8 green, Uint8 blue) : Label(r, Text, size, x, y, xlim, top_left, red, green, blue) {
 }
 
-Label::Label(SDL_Renderer* r, std::string Text, int size, int x, int y, int xlim, Anchor anchor, Uint8 red, Uint8 green, Uint8 blue) : Drawable(anchor) {
+Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xlim, Anchor anchor, Uint8 red, Uint8 green, Uint8 blue) : Drawable(anchor), RendererReference(r) {
     //Save the text assigned to the label in order to be used later
     text = Text;
-
-    //Saving the renderer's reference
-    RendererReference = r;
 
     //Save the color assigned to the label in order to be used later
     Color = { red, green, blue, 0 };

--- a/Label.cpp
+++ b/Label.cpp
@@ -10,7 +10,7 @@ Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, Anch
 Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xlim, Uint8 red, Uint8 green, Uint8 blue) : Label(r, Text, size, x, y, xlim, top_left, red, green, blue) {
 }
 
-Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xlim, Anchor anchor, Uint8 red, Uint8 green, Uint8 blue) : Drawable(anchor), RendererReference(r) {
+Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xlim, Anchor anchor, Uint8 red, Uint8 green, Uint8 blue) : Drawable(anchor), RendererReference(r), FontSize(size) {
     //Save the text assigned to the label in order to be used later
     text = Text;
 
@@ -20,16 +20,7 @@ Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int 
     //Save the label's coordinates
     this->x = x, this->y = y, this->xLim = xlim;
 
-    //Save the label's font size
-    FontSize = size;
-
-    texture = NULL;
     UpdateLabel();
-}
-
-Label::~Label(){
-    //Free up the memory
-    SDL_DestroyTexture(texture);
 }
 
 void Label::pDraw() {
@@ -62,7 +53,7 @@ void Label::ChangePosition(int x, int y) {
     int texW, texH;
 
     //Create the rectangle that will express the size of the texture we created
-    SDL_QueryTexture(texture, NULL, NULL, &texW, &texH);
+    SDL_QueryTexture(texture, nullptr, nullptr, &texW, &texH);
     draw_rect = { x, y, texW, texH };
 
     ApplyAnchor(draw_rect, dAnchor);
@@ -75,21 +66,12 @@ void Label::ChangeXLimit(int xLim) {
 }
 
 void Label::UpdateLabel() {
-    //Free up the memory
-    if (texture != NULL) {
-        SDL_DestroyTexture(texture);
-    }
-
     //Loading the font from the file
-    TTF_Font* font = TTF_OpenFont(GLOBAL_FONT, FontSize);
+    TTF_Font_ctx font(FontSize);
 
     //Convert the text to a surface and then assign the surface to a texture
-    SDL_Surface* surface = TTF_RenderText_Blended_Wrapped(font, text.c_str(), Color, xLim);
-    texture = SDL_CreateTextureFromSurface(RendererReference, surface);
-    SDL_FreeSurface(surface);
-
-    //Delete the font
-    TTF_CloseFont(font);
+    SDL_Surface_ctx surface(TTF_RenderText_Blended_Wrapped(font, text.c_str(), Color, xLim));
+    texture = SDL_Texture_ctx(RendererReference, surface);
 
     ChangePosition(x, y);
 }

--- a/Label.h
+++ b/Label.h
@@ -1,19 +1,23 @@
 #ifndef LABEL_H
 #define LABEL_H
 
-#include <string>
+#include "Drawable.h"
+
+#include "SDL_ctx.h"
+
 #include <SDL.h>
 #include <SDL_ttf.h>
 #include <SDL_image.h>
-#include "Drawable.h"
+
+#include <string>
 
 class Label : public Drawable {
 public:
     //Constructor
-    Label(SDL_Renderer* r, std::string Text, int size, int x, int y, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
-    Label(SDL_Renderer* r, std::string Text, int size, int x, int y, Anchor anchor, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
-    Label(SDL_Renderer* r, std::string Text, int size, int x, int y, int xLim, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
-    Label(SDL_Renderer* r, std::string Text, int size, int x, int y, int xLim, Anchor anchor, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
+    Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
+    Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, Anchor anchor, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
+    Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xLim, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
+    Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xLim, Anchor anchor, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
 
     //Destructor
     ~Label();
@@ -59,7 +63,7 @@ protected:
     std::string text;
 
     //Reference the the screen's renderer
-    SDL_Renderer* RendererReference;
+    RendererRef RendererReference;
 
     //The label's position
     int x, y;

--- a/Label.h
+++ b/Label.h
@@ -19,9 +19,6 @@ public:
     Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xLim, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
     Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int xLim, Anchor anchor, Uint8 red = 0, Uint8 green = 0, Uint8 blue = 0);
 
-    //Destructor
-    ~Label();
-
     //Get the label's text
     std::string GetText();
 
@@ -47,8 +44,11 @@ protected:
     //Render the label on the screen
     void pDraw();
 
-    //The label's font
-    TTF_Font* font;
+    //Reference the the screen's renderer
+    RendererRef RendererReference;
+
+    //The label's font size
+    int FontSize;
 
     //The color of the text displayed by the label
     SDL_Color Color;
@@ -57,19 +57,13 @@ protected:
     SDL_Rect draw_rect;
 
     //The texture containing the text surface
-    SDL_Texture* texture;
+    SDL_Texture_ctx texture;
 
     //The contents of the label
     std::string text;
 
-    //Reference the the screen's renderer
-    RendererRef RendererReference;
-
     //The label's position
     int x, y;
-
-    //The label's font size
-    int FontSize;
 
     //The label's pixel limit in width before it enters a new line
     int xLim;

--- a/MainMenu.cpp
+++ b/MainMenu.cpp
@@ -3,7 +3,7 @@
 #include "MessageBox.h"
 #include "Button.h"
 
-MainMenu::MainMenu(SDL_Renderer* r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r, fp, fpl) {
+MainMenu::MainMenu(SDL_Renderer_ctx& r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r, fp, fpl) {
 	SetupBg("Backgrounds/OldMenu.png");
         auto [Width, Height] = GetWindowDimensions();
 

--- a/MenuSettingsScreen.cpp
+++ b/MenuSettingsScreen.cpp
@@ -3,7 +3,7 @@
 #include "Button.h"
 #include "MainWindow.h"
 
-MenuSettingsScreen::MenuSettingsScreen(SDL_Renderer* r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : BackScreen(r, fp, fpl) {
+MenuSettingsScreen::MenuSettingsScreen(SDL_Renderer_ctx& r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : BackScreen(r, fp, fpl) {
 	SetupBg("Backgrounds/OldMenu.png");
         auto [Width, Height] = GetWindowDimensions();
 

--- a/MessageBox.cpp
+++ b/MessageBox.cpp
@@ -1,8 +1,9 @@
 #include "MessageBox.h"
-#include "MainWindow.h"
+
 #include "Button.h"
-#include "Label.h"
 #include "Image.h"
+#include "Label.h"
+#include "MainWindow.h"
 
 MessageBox::MessageBox(SDL_Renderer_ctx& r, std::string title, std::string message, std::function<void(void*)> f) {
     auto [Width, Height] = GetWindowDimensions();

--- a/MessageBox.cpp
+++ b/MessageBox.cpp
@@ -4,7 +4,7 @@
 #include "Label.h"
 #include "Image.h"
 
-MessageBox::MessageBox(SDL_Renderer* r, std::string title, std::string message, std::function<void(void*)> f) {
+MessageBox::MessageBox(SDL_Renderer_ctx& r, std::string title, std::string message, std::function<void(void*)> f) {
     auto [Width, Height] = GetWindowDimensions();
 
     background = std::make_unique<Image>(r, "Backgrounds/old_paper.png", int(Width * 0.3), int(Height * 0.3), int(Width * 0.4), int(Height * 0.4));

--- a/MessageBox.h
+++ b/MessageBox.h
@@ -15,7 +15,7 @@ class Label;
 class MessageBox : public InputDrawable {
 public:
 	//Constructor
-	MessageBox(SDL_Renderer* r, std::string title, std::string message, std::function<void(void*)> f);
+	MessageBox(SDL_Renderer_ctx& r, std::string title, std::string message, std::function<void(void*)> f);
 
 	//Called when received input
 	void HandleInput(const SDL_Event& ev) override;

--- a/MessageBox.h
+++ b/MessageBox.h
@@ -1,16 +1,15 @@
-#ifndef MESSAGEBOX_H
-#define MESSAGEBOX_H
-
 #pragma once
-#include <SDL.h>
-#include <string>
-#include <functional>
-#include <memory>
+
 #include "Button.h"
 #include "Drawable.h"
+#include "Image.h"
+#include "Label.h"
 
-class Image;
-class Label;
+#include <SDL.h>
+
+#include <functional>
+#include <memory>
+#include <string>
 
 class MessageBox : public InputDrawable {
 public:
@@ -29,5 +28,3 @@ private:
 	std::unique_ptr<Label> text;
 	std::unique_ptr<Button> okButton;
 };
-
-#endif

--- a/OpenFactoryScreen.cpp
+++ b/OpenFactoryScreen.cpp
@@ -6,7 +6,7 @@
 #include "MainWindow.h"
 #include "PlayerController.h"
 
-OpenFactoryScreen::OpenFactoryScreen(SDL_Renderer* r, int id, PlayerController* PC, std::function<void()> quitfunc) : Screen(r, quitfunc){
+OpenFactoryScreen::OpenFactoryScreen(SDL_Renderer_ctx& r, int id, PlayerController* PC, std::function<void()> quitfunc) : Screen(r, quitfunc){
     PCref = PC;
     auto [Width, Height] = GetWindowDimensions();
 

--- a/PauseMenu.cpp
+++ b/PauseMenu.cpp
@@ -3,7 +3,7 @@
 #include "Button.h"
 #include "Image.h"
 
-PauseMenu::PauseMenu(SDL_Renderer* r, std::function<void()> fp, std::function<void()> UnpauseF, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r) {
+PauseMenu::PauseMenu(SDL_Renderer_ctx& r, std::function<void()> fp, std::function<void()> UnpauseF, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r) {
     auto [Width, Height] = GetWindowDimensions();
 
     int fontSize = 32;

--- a/PlayerController.cpp
+++ b/PlayerController.cpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <fstream>
+#include <iostream>
 #include <iterator>
 #include <string>
 #include <thread>
@@ -95,24 +96,21 @@ PlayerController::~PlayerController() {
 	//Remove the map surface and texture from memory
 	SDL_DestroyTexture(txt);
 	SDL_DestroyTexture(overlay);
-	SDL_FreeSurface(map);
-	SDL_FreeSurface(provinces);
 }
 
 int PlayerController::LoadMap(void* pc){
-	PlayerController* PC = static_cast<PlayerController*>(pc);
-	PC->map = IMG_Load("map/1910.png");
+	PlayerController& PC = *static_cast<PlayerController*>(pc);
+	PC.map = IMG_Load("map/1910.png");
 
-	SDL_Surface* base = SDL_CreateRGBSurface(0, 16383, 2160, 32, 0, 0, 0, 0);
+	SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0, 0, 0, 0));
 
 	SDL_Rect strect = { .x = 232, .y = 0, .w = 5616 , .h = 2160 };
-	SDL_BlitSurface(PC->map, &strect, base, NULL);
+	SDL_BlitSurface(PC.map, &strect, base, NULL);
 	strect = { .x = -5616 + 232, .y = 0, .w = 5616 * 2 , .h = 2160 };
-	SDL_BlitSurface(PC->map, &strect, base, NULL);
+	SDL_BlitSurface(PC.map, &strect, base, NULL);
 	strect = { .x = -5616 * 2 + 232, .y = 0, .w = 5616 * 3 , .h = 2160 };
-	SDL_BlitSurface(PC->map, &strect, base, NULL);
-	PC->txt = SDL_CreateTextureFromSurface(PC->RendererReference, base);
-	SDL_FreeSurface(base);
+	SDL_BlitSurface(PC.map, &strect, base, NULL);
+	PC.txt = SDL_CreateTextureFromSurface(PC.RendererReference, base);
 
 	return 0;
 }
@@ -121,9 +119,8 @@ int PlayerController::LoadUtilityAssets(void* pc){
 	PlayerController* PC = (PlayerController*)pc;
 	PC->provinces = IMG_Load("map/provinces.bmp");
 
-	SDL_Surface* base = SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000);
+	SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000));
 	PC->overlay = SDL_CreateTextureFromSurface(PC->RendererReference, base);
-	SDL_FreeSurface(base);
 
 	return 0;
 }

--- a/PlayerController.cpp
+++ b/PlayerController.cpp
@@ -100,8 +100,8 @@ PlayerController::~PlayerController() {
 
 int PlayerController::LoadMap(void* pc){
 	PlayerController& PC = *static_cast<PlayerController*>(pc);
-	PC.map = IMG_Load("map/1910.png");
 
+	PC.map = SDL_Surface_ctx::IMG_Load("map/1910.png");
 	SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0, 0, 0, 0));
 
 	SDL_Rect strect = { .x = 232, .y = 0, .w = 5616 , .h = 2160 };
@@ -110,17 +110,19 @@ int PlayerController::LoadMap(void* pc){
 	SDL_BlitSurface(PC.map, &strect, base, NULL);
 	strect = { .x = -5616 * 2 + 232, .y = 0, .w = 5616 * 3 , .h = 2160 };
 	SDL_BlitSurface(PC.map, &strect, base, NULL);
-	PC.txt = SDL_CreateTextureFromSurface(PC.RendererReference, base);
+
+	PC.txt = SDL_Texture_ctx(PC.RendererReference, base);
 
 	return 0;
 }
 
 int PlayerController::LoadUtilityAssets(void* pc){
-	PlayerController* PC = (PlayerController*)pc;
-	PC->provinces = IMG_Load("map/provinces.bmp");
+	PlayerController& PC = *static_cast<PlayerController*>(pc);
+
+	PC.provinces = SDL_Surface_ctx::IMG_Load("map/provinces.bmp");
 
 	SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000));
-	PC->overlay = SDL_CreateTextureFromSurface(PC->RendererReference, base);
+	PC.overlay = SDL_Texture_ctx(PC.RendererReference, base);
 
 	return 0;
 }

--- a/PlayerController.cpp
+++ b/PlayerController.cpp
@@ -30,10 +30,7 @@ std::vector<T> LoadFromFile(const char* filename) {
 }
 } // namesapce
 
-PlayerController::PlayerController(SDL_Renderer* r, const char* tag) {
-	//Save a reference to the window's renderer
-	RendererReference = r;
-
+PlayerController::PlayerController(SDL_Renderer_ctx& r, const char* tag) : RendererReference(r) {
 	//Save the player's country tag
 	player_tag = tag;
 

--- a/PlayerController.cpp
+++ b/PlayerController.cpp
@@ -92,10 +92,6 @@ PlayerController::~PlayerController() {
 	if (Date.bIsPaused == false) {
 		Pause();
 	}
-
-	//Remove the map surface and texture from memory
-	SDL_DestroyTexture(txt);
-	SDL_DestroyTexture(overlay);
 }
 
 int PlayerController::LoadMap(void* pc){

--- a/PlayerController.h
+++ b/PlayerController.h
@@ -74,7 +74,6 @@ public:
 	//Some SDL assets needed
 	RendererRef RendererReference;
 	SDL_Texture_ctx txt;
-
 	SDL_Texture_ctx overlay;
 	SDL_Surface_ctx map;
 	SDL_Surface_ctx provinces;

--- a/PlayerController.h
+++ b/PlayerController.h
@@ -76,8 +76,8 @@ public:
 	SDL_Texture* txt;
 
 	SDL_Texture* overlay;
-	SDL_Surface* map;
-	SDL_Surface* provinces;
+	SDL_Surface_ctx map;
+	SDL_Surface_ctx provinces;
 
 	//Used to run the time-functionality of the game
 	SDL_Thread* thread;

--- a/PlayerController.h
+++ b/PlayerController.h
@@ -73,9 +73,9 @@ public:
 
 	//Some SDL assets needed
 	RendererRef RendererReference;
-	SDL_Texture* txt;
+	SDL_Texture_ctx txt;
 
-	SDL_Texture* overlay;
+	SDL_Texture_ctx overlay;
 	SDL_Surface_ctx map;
 	SDL_Surface_ctx provinces;
 

--- a/PlayerController.h
+++ b/PlayerController.h
@@ -6,19 +6,20 @@
 #include "Country.h"
 #include "Diplomacy.h"
 #include "State.h"
+#include "SDL_ctx.h"
 
 #include <SDL.h>
 
+#include <array>
 #include <cstdint>
 #include <memory>
-#include <array>
 #include <unordered_map>
 #include <vector>
 
 class PlayerController {
 public:
 	//Constructor
-	PlayerController(SDL_Renderer* r, const char* tag);
+	PlayerController(SDL_Renderer_ctx& r, const char* tag);
 
     ~PlayerController();
 
@@ -71,7 +72,7 @@ public:
 	Diplomacy diplo;
 
 	//Some SDL assets needed
-	SDL_Renderer* RendererReference;
+	RendererRef RendererReference;
 	SDL_Texture* txt;
 
 	SDL_Texture* overlay;

--- a/SDL_ColorDetection.cpp
+++ b/SDL_ColorDetection.cpp
@@ -1,6 +1,6 @@
 #include "SDL_ColorDetection.h"
 
-Uint32 CD::getpixel(SDL_Surface* surface, int x, int y){
+Uint32 CD::getpixel(SDL_Surface_ctx& surface, int x, int y){
 	//Get the bit depth of the surface
 	int bpp = surface->format->BytesPerPixel;
 
@@ -33,7 +33,7 @@ Uint32 CD::getpixel(SDL_Surface* surface, int x, int y){
 	}
 }
 
-Color CD::getcolor(SDL_Surface* surface, int x, int y) {
+Color CD::getcolor(SDL_Surface_ctx& surface, int x, int y) {
 	Color rgb;
 
 	//Get the requested pixel's data

--- a/SDL_ColorDetection.h
+++ b/SDL_ColorDetection.h
@@ -1,17 +1,19 @@
 #ifndef SDL_COLORDETECTION_CPP
 #define SDL_COLORDETECTION_CPP
 
-#include <SDL.h>
-#include <iostream>
 #include "Color.h"
+
+#include "SDL_ctx.h"
+
+#include <SDL.h>
 
 //Color Detection(CD) namespace
 namespace CD {
 	//Return the selected pixel's data
-	Uint32 getpixel(SDL_Surface* surface, int x, int y);
+	Uint32 getpixel(SDL_Surface_ctx& surface, int x, int y);
 
 	//Extract the pixel's color from it's data
-	Color getcolor(SDL_Surface* surface, int x, int y);
+	Color getcolor(SDL_Surface_ctx& surface, int x, int y);
 }
 
 #endif

--- a/SDL_ctx.cpp
+++ b/SDL_ctx.cpp
@@ -93,3 +93,11 @@ SDL_Texture_ctx SDL_Texture_ctx::IMG_Load(SDL_Renderer_ctx& r, std::string_view 
     return {r, surface};
 }
 //-----------------------------------------------------------------------------
+TTF_Font_ctx::TTF_Font_ctx(int ptsize) : TTF_Font_ctx("Fonts/segoeui.ttf", ptsize) {}
+TTF_Font_ctx::TTF_Font_ctx(std::string_view filename, int ptsize) :
+    font(TTF_OpenFont(filename.data(), ptsize), &TTF_CloseFont)
+{}
+
+TTF_Font* TTF_Font_ctx::operator->() { return font.get(); }
+TTF_Font_ctx::operator TTF_Font* () { return font.get(); }
+//-----------------------------------------------------------------------------

--- a/SDL_ctx.cpp
+++ b/SDL_ctx.cpp
@@ -9,38 +9,6 @@ SDL_Init_ctx::~SDL_Init_ctx() {
     SDL_Quit();
 }
 //-----------------------------------------------------------------------------
-SDL_Window_ctx::SDL_Window_ctx() : window(SDL_CreateWindow(
-        "The Great War",                  // window title
-        SDL_WINDOWPOS_UNDEFINED,          // initial x position
-        SDL_WINDOWPOS_UNDEFINED,          // initial y position
-        1920,                             // width, in pixels
-        1080,                             // height, in pixels
-        SDL_WINDOW_OPENGL //| SDL_WINDOW_FULLSCREEN                  // flags - see below
-    ))
-    //2560x1440, 1920x1080, 1280x720
-{
-    //Get dimensions of the screen
-    SDL_GetWindowSize(window, &windim.x, &windim.y);
-}
-
-SDL_Window_ctx::~SDL_Window_ctx() {
-    SDL_DestroyWindow(window);
-}
-
-SDL_Window* SDL_Window_ctx::operator->() { return window; }
-
-SDL_Window_ctx::operator SDL_Window* () { return window; }
-//-----------------------------------------------------------------------------
-SDL_Renderer_ctx::SDL_Renderer_ctx(SDL_Window_ctx& window) : renderer(SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC)) {}
-
-SDL_Renderer_ctx::~SDL_Renderer_ctx() {
-    SDL_DestroyRenderer(renderer);
-}
-
-SDL_Renderer* SDL_Renderer_ctx::operator->() { return renderer; }
-
-SDL_Renderer_ctx::operator SDL_Renderer* () { return renderer; }
-//-----------------------------------------------------------------------------
 TTF_Init_ctx::TTF_Init_ctx() {
     TTF_Init();
 }
@@ -66,18 +34,58 @@ MIX_ctx::~MIX_ctx() {
     Mix_Quit();
 }
 //-----------------------------------------------------------------------------
-SDL_Cursor_ctx::SDL_Cursor_ctx() {
-    SDL_Surface* surface = IMG_Load("Icons/mouse.png");
-    cursor = SDL_CreateColorCursor(surface, 1, 1);
-    SDL_SetCursor(cursor);
-    SDL_FreeSurface(surface);
+SDL_Window_ctx::SDL_Window_ctx() : window(SDL_CreateWindow(
+        "The Great War",                  // window title
+        SDL_WINDOWPOS_UNDEFINED,          // initial x position
+        SDL_WINDOWPOS_UNDEFINED,          // initial y position
+        1920,                             // width, in pixels
+        1080,                             // height, in pixels
+        SDL_WINDOW_OPENGL //| SDL_WINDOW_FULLSCREEN                  // flags - see below
+    ), &SDL_DestroyWindow)
+    //2560x1440, 1920x1080, 1280x720
+{
+    //Get dimensions of the screen
+    SDL_GetWindowSize(*this, &windim.x, &windim.y);
 }
 
-SDL_Cursor_ctx::~SDL_Cursor_ctx() {
-    SDL_FreeCursor(cursor);
+SDL_Window* SDL_Window_ctx::operator->() { return window.get(); }
+SDL_Window_ctx::operator SDL_Window* () { return window.get(); }
+//-----------------------------------------------------------------------------
+SDL_Renderer_ctx::SDL_Renderer_ctx(SDL_Window_ctx& window) :
+    renderer(SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED |
+                                            SDL_RENDERER_PRESENTVSYNC),
+             &SDL_DestroyRenderer)
+{}
+
+SDL_Renderer* SDL_Renderer_ctx::operator->() { return renderer.get(); }
+SDL_Renderer_ctx::operator SDL_Renderer* () { return renderer.get(); }
+//-----------------------------------------------------------------------------
+SDL_Surface_ctx::SDL_Surface_ctx() : SDL_Surface_ctx(nullptr) {}
+SDL_Surface_ctx::SDL_Surface_ctx(SDL_Surface* s) : surface(s, &SDL_FreeSurface) {}
+
+SDL_Surface_ctx& SDL_Surface_ctx::operator=(SDL_Surface* s) {
+    surface.reset(s);
+    return *this;
 }
 
-SDL_Cursor* SDL_Cursor_ctx::operator->() { return cursor; }
+SDL_Surface* SDL_Surface_ctx::operator->() { return surface.get(); }
+SDL_Surface_ctx::operator SDL_Surface* () { return surface.get(); }
+SDL_Surface_ctx::operator const SDL_Surface* () const { return surface.get(); }
+//-----------------------------------------------------------------------------
+SDL_Cursor_ctx::SDL_Cursor_ctx() :
+    cursor(SDL_CreateColorCursor(SDL_Surface_ctx(IMG_Load("Icons/mouse.png")), 1, 1), &SDL_FreeCursor)
+{
+    SDL_SetCursor(*this);
+}
 
-SDL_Cursor_ctx::operator SDL_Cursor* () { return cursor; }
+SDL_Cursor* SDL_Cursor_ctx::operator->() { return cursor.get(); }
+SDL_Cursor_ctx::operator SDL_Cursor* () { return cursor.get(); }
+//-----------------------------------------------------------------------------
+SDL_Texture_ctx::SDL_Texture_ctx() : texture(nullptr, &SDL_DestroyTexture) {}
+SDL_Texture_ctx::SDL_Texture_ctx(SDL_Renderer_ctx& r, SDL_Surface_ctx& s) :
+    texture(SDL_CreateTextureFromSurface(r, s), &SDL_DestroyTexture)
+{}
+
+SDL_Texture* SDL_Texture_ctx::operator->() { return texture.get(); }
+SDL_Texture_ctx::operator SDL_Texture* () { return texture.get(); }
 //-----------------------------------------------------------------------------

--- a/SDL_ctx.cpp
+++ b/SDL_ctx.cpp
@@ -60,6 +60,15 @@ SDL_Renderer_ctx::SDL_Renderer_ctx(SDL_Window_ctx& window) :
 SDL_Renderer* SDL_Renderer_ctx::operator->() { return renderer.get(); }
 SDL_Renderer_ctx::operator SDL_Renderer* () { return renderer.get(); }
 //-----------------------------------------------------------------------------
+SDL_Cursor_ctx::SDL_Cursor_ctx() :
+    cursor(SDL_CreateColorCursor(SDL_Surface_ctx(IMG_Load("Icons/mouse.png")), 1, 1), &SDL_FreeCursor)
+{
+    SDL_SetCursor(*this);
+}
+
+SDL_Cursor* SDL_Cursor_ctx::operator->() { return cursor.get(); }
+SDL_Cursor_ctx::operator SDL_Cursor* () { return cursor.get(); }
+//-----------------------------------------------------------------------------
 SDL_Surface_ctx::SDL_Surface_ctx() : SDL_Surface_ctx(nullptr) {}
 SDL_Surface_ctx::SDL_Surface_ctx(SDL_Surface* s) : surface(s, &SDL_FreeSurface) {}
 
@@ -71,15 +80,10 @@ SDL_Surface_ctx& SDL_Surface_ctx::operator=(SDL_Surface* s) {
 SDL_Surface* SDL_Surface_ctx::operator->() { return surface.get(); }
 SDL_Surface_ctx::operator SDL_Surface* () { return surface.get(); }
 SDL_Surface_ctx::operator const SDL_Surface* () const { return surface.get(); }
-//-----------------------------------------------------------------------------
-SDL_Cursor_ctx::SDL_Cursor_ctx() :
-    cursor(SDL_CreateColorCursor(SDL_Surface_ctx(IMG_Load("Icons/mouse.png")), 1, 1), &SDL_FreeCursor)
-{
-    SDL_SetCursor(*this);
-}
 
-SDL_Cursor* SDL_Cursor_ctx::operator->() { return cursor.get(); }
-SDL_Cursor_ctx::operator SDL_Cursor* () { return cursor.get(); }
+SDL_Surface_ctx SDL_Surface_ctx::IMG_Load(std::string_view filename) {
+    return SDL_Surface_ctx(::IMG_Load(filename.data()));
+}
 //-----------------------------------------------------------------------------
 SDL_Texture_ctx::SDL_Texture_ctx() : texture(nullptr, &SDL_DestroyTexture) {}
 SDL_Texture_ctx::SDL_Texture_ctx(SDL_Renderer_ctx& r, SDL_Surface_ctx& s) :
@@ -88,4 +92,9 @@ SDL_Texture_ctx::SDL_Texture_ctx(SDL_Renderer_ctx& r, SDL_Surface_ctx& s) :
 
 SDL_Texture* SDL_Texture_ctx::operator->() { return texture.get(); }
 SDL_Texture_ctx::operator SDL_Texture* () { return texture.get(); }
+
+SDL_Texture_ctx SDL_Texture_ctx::IMG_Load(SDL_Renderer_ctx& r, std::string_view filename) {
+    auto surface = SDL_Surface_ctx::IMG_Load(filename);
+    return {r, surface};
+}
 //-----------------------------------------------------------------------------

--- a/SDL_ctx.cpp
+++ b/SDL_ctx.cpp
@@ -72,11 +72,6 @@ SDL_Cursor_ctx::operator SDL_Cursor* () { return cursor.get(); }
 SDL_Surface_ctx::SDL_Surface_ctx() : SDL_Surface_ctx(nullptr) {}
 SDL_Surface_ctx::SDL_Surface_ctx(SDL_Surface* s) : surface(s, &SDL_FreeSurface) {}
 
-SDL_Surface_ctx& SDL_Surface_ctx::operator=(SDL_Surface* s) {
-    surface.reset(s);
-    return *this;
-}
-
 SDL_Surface* SDL_Surface_ctx::operator->() { return surface.get(); }
 SDL_Surface_ctx::operator SDL_Surface* () { return surface.get(); }
 SDL_Surface_ctx::operator const SDL_Surface* () const { return surface.get(); }

--- a/SDL_ctx.h
+++ b/SDL_ctx.h
@@ -177,3 +177,20 @@ public:
 private:
     std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)> texture;
 };
+//-----------------------------------------------------------------------------
+class TTF_Font_ctx {
+public:
+    TTF_Font_ctx(int ptsize); // use the default
+    explicit TTF_Font_ctx(std::string_view filename, int ptsize);
+
+    TTF_Font_ctx(const TTF_Font_ctx&) = delete;
+    TTF_Font_ctx(TTF_Font_ctx&&) noexcept = default;
+    TTF_Font_ctx& operator=(const TTF_Font_ctx&) = delete;
+    TTF_Font_ctx& operator=(TTF_Font_ctx&&) noexcept = default;
+    ~TTF_Font_ctx() = default;
+
+    TTF_Font* operator->();
+    operator TTF_Font* ();
+private:
+    std::unique_ptr<TTF_Font, decltype(&TTF_CloseFont)> font;
+};

--- a/SDL_ctx.h
+++ b/SDL_ctx.h
@@ -7,6 +7,7 @@
 #include <SDL_ttf.h>
 
 #include <memory>
+#include <string_view>
 
 /*-----------------------------------------------------------------------------
 The promiscuous_ref is to be used while converting from storing
@@ -154,6 +155,8 @@ public:
     SDL_Surface* operator->();
     operator SDL_Surface* ();
     operator const SDL_Surface* () const;
+
+    static SDL_Surface_ctx IMG_Load(std::string_view filename);
 private:
     std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)> surface;
 };
@@ -171,6 +174,8 @@ public:
 
     SDL_Texture* operator->();
     operator SDL_Texture* ();
+
+    static SDL_Texture_ctx IMG_Load(SDL_Renderer_ctx& r, std::string_view filename);
 private:
     std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)> texture;
 };

--- a/SDL_ctx.h
+++ b/SDL_ctx.h
@@ -6,8 +6,9 @@
 #include <SDL_thread.h>
 #include <SDL_ttf.h>
 
-/*
+#include <memory>
 
+/*-----------------------------------------------------------------------------
 The promiscuous_ref is to be used while converting from storing
 pointers to SDL objects to storing instances of RAII SDL wrappers.
 
@@ -22,9 +23,7 @@ pointers to SDL objects to storing instances of RAII SDL wrappers.
 
 The idea is to gradually remove parts of the promiscuous_refs interface
 until it can be replaced by a std::reference_wrapper.
-
-*/
-
+-----------------------------------------------------------------------------*/
 template<class T, class U>
 class promiscuous_ref {
 public:
@@ -48,58 +47,25 @@ public:
 private:
     T* obj = nullptr;
 };
-
+//-----------------------------------------------------------------------------
+// classes not owning any actual resources
 class SDL_Init_ctx {
 public:
     SDL_Init_ctx();
     SDL_Init_ctx(const SDL_Init_ctx&) = delete;
-    SDL_Init_ctx(SDL_Init_ctx&&) = delete;
+    SDL_Init_ctx(SDL_Init_ctx&&) noexcept = default;
     SDL_Init_ctx& operator=(const SDL_Init_ctx&) = delete;
-    SDL_Init_ctx& operator=(SDL_Init_ctx&&) = delete;
+    SDL_Init_ctx& operator=(SDL_Init_ctx&&) noexcept = default;
     ~SDL_Init_ctx();
 };
-
-class SDL_Window_ctx {
-public:
-    SDL_Window_ctx();
-    SDL_Window_ctx(const SDL_Window_ctx&) = delete;
-    SDL_Window_ctx(SDL_Window_ctx&&) = delete;
-    SDL_Window_ctx& operator=(const SDL_Window_ctx&) = delete;
-    SDL_Window_ctx& operator=(SDL_Window_ctx&&) = delete;
-    ~SDL_Window_ctx();
-
-    inline const SDL_Point& GetWindowDimensions() const { return windim; }
-
-    SDL_Window* operator->();
-    operator SDL_Window* ();
-private:
-    SDL_Window* window;
-    SDL_Point windim;
-};
-
-class SDL_Renderer_ctx {
-public:
-    explicit SDL_Renderer_ctx(SDL_Window_ctx& window);
-    SDL_Renderer_ctx(const SDL_Renderer_ctx&) = delete;
-    SDL_Renderer_ctx(SDL_Renderer_ctx&&) = delete;
-    SDL_Renderer_ctx& operator=(const SDL_Renderer_ctx&) = delete;
-    SDL_Renderer_ctx& operator=(SDL_Renderer_ctx&&) = delete;
-    ~SDL_Renderer_ctx();
-
-    SDL_Renderer* operator->();
-    operator SDL_Renderer* ();
-private:
-    SDL_Renderer* renderer;
-};
-using RendererRef = promiscuous_ref<SDL_Renderer_ctx, SDL_Renderer>;
 
 class TTF_Init_ctx {
 public:
     TTF_Init_ctx();
     TTF_Init_ctx(const TTF_Init_ctx&) = delete;
-    TTF_Init_ctx(TTF_Init_ctx&&) = delete;
+    TTF_Init_ctx(TTF_Init_ctx&&) noexcept = default;
     TTF_Init_ctx& operator=(const TTF_Init_ctx&) = delete;
-    TTF_Init_ctx& operator=(TTF_Init_ctx&&) = delete;
+    TTF_Init_ctx& operator=(TTF_Init_ctx&&) noexcept = default;
     ~TTF_Init_ctx();
 };
 
@@ -107,9 +73,9 @@ class IMG_Init_ctx {
 public:
     IMG_Init_ctx();
     IMG_Init_ctx(const IMG_Init_ctx&) = delete;
-    IMG_Init_ctx(IMG_Init_ctx&&) = delete;
+    IMG_Init_ctx(IMG_Init_ctx&&) noexcept = default;
     IMG_Init_ctx& operator=(const IMG_Init_ctx&) = delete;
-    IMG_Init_ctx& operator=(IMG_Init_ctx&&) = delete;
+    IMG_Init_ctx& operator=(IMG_Init_ctx&&) noexcept = default;
     ~IMG_Init_ctx();
 };
 
@@ -117,23 +83,94 @@ class MIX_ctx {
 public:
     MIX_ctx();
     MIX_ctx(const MIX_ctx&) = delete;
-    MIX_ctx(MIX_ctx&&) = delete;
+    MIX_ctx(MIX_ctx&&) noexcept = default;
     MIX_ctx& operator=(const MIX_ctx&) = delete;
-    MIX_ctx& operator=(MIX_ctx&&) = delete;
+    MIX_ctx& operator=(MIX_ctx&&) noexcept = default;
     ~MIX_ctx();
 };
+//-----------------------------------------------------------------------------
+class SDL_Window_ctx {
+public:
+    SDL_Window_ctx();
+    SDL_Window_ctx(const SDL_Window_ctx&) = delete;
+    SDL_Window_ctx(SDL_Window_ctx&&) noexcept = default;
+    SDL_Window_ctx& operator=(const SDL_Window_ctx&) = delete;
+    SDL_Window_ctx& operator=(SDL_Window_ctx&&) noexcept = default;
+    ~SDL_Window_ctx() = default;
+
+    inline const SDL_Point& GetWindowDimensions() const { return windim; }
+
+    SDL_Window* operator->();
+    operator SDL_Window* ();
+private:
+    std::unique_ptr<SDL_Window, decltype(&SDL_DestroyWindow)> window;
+    SDL_Point windim;
+};
+
+class SDL_Renderer_ctx {
+public:
+    explicit SDL_Renderer_ctx(SDL_Window_ctx& window);
+    SDL_Renderer_ctx(const SDL_Renderer_ctx&) = delete;
+    SDL_Renderer_ctx(SDL_Renderer_ctx&&) noexcept = default;
+    SDL_Renderer_ctx& operator=(const SDL_Renderer_ctx&) = delete;
+    SDL_Renderer_ctx& operator=(SDL_Renderer_ctx&&) noexcept = default;
+    ~SDL_Renderer_ctx() = default;
+
+    SDL_Renderer* operator->();
+    operator SDL_Renderer* ();
+private:
+    std::unique_ptr<SDL_Renderer, decltype(&SDL_DestroyRenderer)> renderer;
+};
+using RendererRef = promiscuous_ref<SDL_Renderer_ctx, SDL_Renderer>;
 
 class SDL_Cursor_ctx {
 public:
     SDL_Cursor_ctx();
     SDL_Cursor_ctx(const SDL_Cursor_ctx&) = delete;
-    SDL_Cursor_ctx(SDL_Cursor_ctx&&) = delete;
+    SDL_Cursor_ctx(SDL_Cursor_ctx&&) noexcept = default;
     SDL_Cursor_ctx& operator=(const SDL_Cursor_ctx&) = delete;
-    SDL_Cursor_ctx& operator=(SDL_Cursor_ctx&&) = delete;
-    ~SDL_Cursor_ctx();
+    SDL_Cursor_ctx& operator=(SDL_Cursor_ctx&&) noexcept = default;
+    ~SDL_Cursor_ctx() = default;
 
     SDL_Cursor* operator->();
     operator SDL_Cursor* ();
 private:
-    SDL_Cursor* cursor;
+    std::unique_ptr<SDL_Cursor, decltype(&SDL_FreeCursor)> cursor;
+};
+
+class SDL_Surface_ctx {
+public:
+    SDL_Surface_ctx(); // non-owning
+    explicit SDL_Surface_ctx(SDL_Surface*); // take ownership of a raw pointer
+
+    SDL_Surface_ctx(const SDL_Surface_ctx&) = delete;
+    SDL_Surface_ctx(SDL_Surface_ctx&&) noexcept = default;
+    SDL_Surface_ctx& operator=(const SDL_Surface_ctx&) = delete;
+    SDL_Surface_ctx& operator=(SDL_Surface_ctx&&) noexcept = default;
+    ~SDL_Surface_ctx() = default;
+
+    SDL_Surface_ctx& operator=(SDL_Surface*); // take ownership of a raw pointer
+
+    SDL_Surface* operator->();
+    operator SDL_Surface* ();
+    operator const SDL_Surface* () const;
+private:
+    std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)> surface;
+};
+
+class SDL_Texture_ctx {
+public:
+    SDL_Texture_ctx(); // non-owning
+    SDL_Texture_ctx(SDL_Renderer_ctx&, SDL_Surface_ctx&);
+
+    SDL_Texture_ctx(const SDL_Texture_ctx&) = delete;
+    SDL_Texture_ctx(SDL_Texture_ctx&&) noexcept = default;
+    SDL_Texture_ctx& operator=(const SDL_Texture_ctx&) = delete;
+    SDL_Texture_ctx& operator=(SDL_Texture_ctx&&) noexcept = default;
+    ~SDL_Texture_ctx() = default;
+
+    SDL_Texture* operator->();
+    operator SDL_Texture* ();
+private:
+    std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)> texture;
 };

--- a/SDL_ctx.h
+++ b/SDL_ctx.h
@@ -150,8 +150,6 @@ public:
     SDL_Surface_ctx& operator=(SDL_Surface_ctx&&) noexcept = default;
     ~SDL_Surface_ctx() = default;
 
-    SDL_Surface_ctx& operator=(SDL_Surface*); // take ownership of a raw pointer
-
     SDL_Surface* operator->();
     operator SDL_Surface* ();
     operator const SDL_Surface* () const;

--- a/Screen.cpp
+++ b/Screen.cpp
@@ -5,11 +5,11 @@
 
 #include <iostream>
 
-Screen::Screen(SDL_Renderer* r) : renderer(r) {
+Screen::Screen(SDL_Renderer_ctx& r) : renderer(r) {
     std::cerr << "Screen::Screen()\t" << static_cast<void*>(this) << std::endl;
 }
 
-Screen::Screen(SDL_Renderer* r, std::function<void()> qf, std::function<void(std::unique_ptr<Screen>)> csf) : renderer(r), QuitFunc(qf), ChangeScreenFunc(csf) {
+Screen::Screen(SDL_Renderer_ctx& r, std::function<void()> qf, std::function<void(std::unique_ptr<Screen>)> csf) : renderer(r), QuitFunc(qf), ChangeScreenFunc(csf) {
     std::cerr << "Screen::Screen(...)\t" << static_cast<void*>(this) << std::endl;
 }
 

--- a/Screen.cpp
+++ b/Screen.cpp
@@ -13,21 +13,13 @@ Screen::Screen(SDL_Renderer_ctx& r, std::function<void()> qf, std::function<void
     std::cerr << "Screen::Screen(...)\t" << static_cast<void*>(this) << std::endl;
 }
 
-Screen::~Screen(){
-	//Free all the allocated memory
-	if (bHasBackground) {
-		SDL_DestroyTexture(texture);
-	}
-        std::cerr << "Screen::~Screen\t" << static_cast<void*>(this) << std::endl;
-}
-
 void Screen::RenderBackground() {
 	/*Check if the rendered Image must be zoomed.
 	If it musn't, then we just cope the image to the surface.
 	If it does, then we create a rectangle and give it the
 	appropriate dimensions, based on the magnification
 	factor reiceived from user input*/
-	if (bHasBackground) {
+	if (texture) {
             SDL_RenderCopy(renderer, texture, NULL, NULL);
         }
 }
@@ -67,13 +59,8 @@ void Screen::Handle_Input(SDL_Event& ev){
 }
 
 void Screen::SetupBg(const char* bg) {
-    if(bHasBackground) {
-        SDL_DestroyTexture(texture);
-    } else bHasBackground = true;
-
-    SDL_Surface* img = IMG_Load(bg);
-    texture = SDL_CreateTextureFromSurface(renderer, img);
-    SDL_FreeSurface(img);
+    bHasBackground = true;
+    texture = SDL_Texture_ctx::IMG_Load(renderer, bg);
 }
 
 void Screen::DeleteMessageBox(void* p) {

--- a/Screen.h
+++ b/Screen.h
@@ -5,6 +5,8 @@
 #include "Image.h"
 #include "Label.h"
 
+#include "SDL_ctx.h"
+
 #include <SDL.h>
 #include <SDL_image.h>
 
@@ -19,8 +21,8 @@ class MessageBox;
 class Screen{
 public:
     //Constructor
-    Screen(SDL_Renderer* r);
-    Screen(SDL_Renderer* r, std::function<void()> qf, std::function<void(std::unique_ptr<Screen>)> csf = {});
+    Screen(SDL_Renderer_ctx& r);
+    Screen(SDL_Renderer_ctx& r, std::function<void()> qf, std::function<void(std::unique_ptr<Screen>)> csf = {});
 
     //Destructor
     virtual ~Screen();
@@ -35,7 +37,7 @@ public:
 
 protected:
     //This is a reference to the main window's renderer
-    SDL_Renderer* renderer;
+    RendererRef renderer;
 
     //Allows the creation of Images on the screen
     std::vector<std::unique_ptr<Image>> ImageArr;

--- a/Screen.h
+++ b/Screen.h
@@ -4,6 +4,7 @@
 #include "Drawable.h"
 #include "Image.h"
 #include "Label.h"
+#include "MessageBox.h"
 
 #include "SDL_ctx.h"
 
@@ -16,16 +17,13 @@
 #include <string>
 #include <vector>
 
-class MessageBox;
-
 class Screen{
 public:
     //Constructor
     Screen(SDL_Renderer_ctx& r);
     Screen(SDL_Renderer_ctx& r, std::function<void()> qf, std::function<void(std::unique_ptr<Screen>)> csf = {});
 
-    //Destructor
-    virtual ~Screen();
+    virtual ~Screen() = default;
 
     //Renders all of the screen's components
     virtual void Render();
@@ -76,7 +74,7 @@ protected:
     bool bHasBackground = false;
 
     //Stores the image's texture
-    SDL_Texture* texture = nullptr;
+    SDL_Texture_ctx texture;
 
     std::function<void()> QuitFunc;
     std::function<void(std::unique_ptr<Screen>)> ChangeScreenFunc;

--- a/ScreenList.h
+++ b/ScreenList.h
@@ -3,6 +3,8 @@
 #include "Screen.h"
 #include "UI.h"
 
+#include "SDL_ctx.h"
+
 #include <SDL.h>
 #include <SDL_image.h>
 
@@ -18,7 +20,7 @@ class Country;
 class MainMenu : public Screen {
 public:
     //Constructor, sets default values and creates all needed assets
-    MainMenu(SDL_Renderer* r, std::function<void()> fp , std::function<void(std::unique_ptr<Screen>)> fpl );
+    MainMenu(SDL_Renderer_ctx& r, std::function<void()> fp , std::function<void(std::unique_ptr<Screen>)> fpl );
 
     void ShowCredits();
     void ShowSettings();
@@ -27,7 +29,7 @@ public:
 
 class BackScreen : public Screen {
 public:
-    inline BackScreen(SDL_Renderer* r,  std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r, fp, fpl) {}
+    inline BackScreen(SDL_Renderer_ctx& r,  std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(r, fp, fpl) {}
 
     inline void Back() {
         ChangeScreenFunc(std::make_unique<MainMenu>(renderer, QuitFunc, ChangeScreenFunc));
@@ -36,13 +38,13 @@ public:
 
 class CreditScreen : public BackScreen {
 public:
-    CreditScreen(SDL_Renderer* r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl);
+    CreditScreen(SDL_Renderer_ctx& r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl);
 };
 
 class MenuSettingsScreen : public BackScreen {
 public:
     //Constructor, sets default values and creates all needed assets
-    MenuSettingsScreen(SDL_Renderer* r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl);
+    MenuSettingsScreen(SDL_Renderer_ctx& r, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl);
 };
 
 class InGameSettingsScreen : public Screen {
@@ -52,7 +54,7 @@ public:
 class GameScreen : public Screen {
 public:
     //Constructor, sets default values and creates all needed assets
-    GameScreen(SDL_Renderer* r, const char* tag, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl);
+    GameScreen(SDL_Renderer_ctx& r, const char* tag, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl);
 
     std::unique_ptr<PlayerController> PC;
 
@@ -109,14 +111,14 @@ public:
 class PauseMenu : public Screen {
 public:
     //Constructor, sets default values and creates all needed assets
-    PauseMenu(SDL_Renderer* r, std::function<void()> fp = {}, std::function<void()> UnpauseF = {}, std::function<void(std::unique_ptr<Screen>)> fpl = {});
+    PauseMenu(SDL_Renderer_ctx& r, std::function<void()> fp = {}, std::function<void()> UnpauseF = {}, std::function<void(std::unique_ptr<Screen>)> fpl = {});
 
     void ReturnToMainMenu();
 };
 
 class CountrySelection : public Screen {
 public:
-    CountrySelection(SDL_Renderer* r, std::function<void()> UnpauseF = {}, std::function<void(std::unique_ptr<Screen>)> fpl = {});
+    CountrySelection(SDL_Renderer_ctx& r, std::function<void()> UnpauseF = {}, std::function<void(std::unique_ptr<Screen>)> fpl = {});
 
     bool mousepressed;
 
@@ -144,9 +146,9 @@ public:
 
 class DiplomacyScreen : public Screen {
 public:
-    DiplomacyScreen(SDL_Renderer* r, PlayerController* PC);
-    DiplomacyScreen(SDL_Renderer* r, PlayerController* PC, std::string targetTag);
-    DiplomacyScreen(SDL_Renderer* r, PlayerController* PC, int index);
+    DiplomacyScreen(SDL_Renderer_ctx& r, PlayerController* PC);
+    DiplomacyScreen(SDL_Renderer_ctx& r, PlayerController* PC, std::string targetTag);
+    DiplomacyScreen(SDL_Renderer_ctx& r, PlayerController* PC, int index);
 
     PlayerController* PCref;
 
@@ -170,13 +172,13 @@ private:
 
 class IndustryScreen : public Screen {
 public:
-    IndustryScreen(SDL_Renderer* r, int Stockpile[30]);
+    IndustryScreen(SDL_Renderer_ctx& r, int Stockpile[30]);
     void UpdateText(int Stockpile[29]);
 };
 
 class TradeScreen : public Screen {
 public:
-    TradeScreen(SDL_Renderer* r, Country* Pl);
+    TradeScreen(SDL_Renderer_ctx& r, Country* Pl);
     void Update();
 
 private:
@@ -185,7 +187,7 @@ private:
 
 class EconomyScreen : public Screen {
 public:
-    EconomyScreen(SDL_Renderer* r, Country* Pl);
+    EconomyScreen(SDL_Renderer_ctx& r, Country* Pl);
 
     void Update();
 
@@ -198,7 +200,7 @@ public:
 
 class OpenFactoryScreen : public Screen {
 public:
-    OpenFactoryScreen(SDL_Renderer* r, int id, PlayerController* PC, std::function<void()> fp);
+    OpenFactoryScreen(SDL_Renderer_ctx& r, int id, PlayerController* PC, std::function<void()> fp);
 
     void FactoryTypeLumber();
     void FactoryTypeGlass();
@@ -238,7 +240,7 @@ public:
 
 class StatePreview : public Screen {
 public:
-    StatePreview(SDL_Renderer* r, int id, std::string StateName, std::string controller, PlayerController* PC, int res[8], int pop, std::string Factories[4], std::function<void()> CloseFunc, std::function<void(std::unique_ptr<Screen>, std::string)> ChangeScreenFunc);
+    StatePreview(SDL_Renderer_ctx& r, int id, std::string StateName, std::string controller, PlayerController* PC, int res[8], int pop, std::string Factories[4], std::function<void()> CloseFunc, std::function<void(std::unique_ptr<Screen>, std::string)> ChangeScreenFunc);
 
     void Render() override;
 

--- a/ScreenList.h
+++ b/ScreenList.h
@@ -94,9 +94,6 @@ public:
     int MouseSensitivity;
 
     std::unique_ptr<Screen> StateViewingScreen;
-    //bool bHasStatePreview;
-
-    SDL_Texture* assets;
 
     void HandleMouseMovement(SDL_Event& ev);
     void ChangeActiveScreen(std::unique_ptr<Screen> NewScreen, std::string ID);

--- a/Slider.cpp
+++ b/Slider.cpp
@@ -8,23 +8,13 @@ Slider::Slider(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, int min
 {}
 
 Slider::Slider(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, Anchor anchor, int minvalue, int maxvalue, int value, std::function<void()> onSliderValueChanged)
-    : InputDrawable(anchor), renderer(r)
+    : InputDrawable(anchor), renderer(r), Marker(SDL_Texture_ctx::IMG_Load(renderer, "Drawable/Slider/Circle.png"))
 {
 	//Initialize all variables
 	ChangeValues(minvalue, maxvalue, value);
 	ChangePosition(x, y, Width, Height);
 
-	//Load the slider's textures
-	SDL_Surface* temp = IMG_Load("Drawable/Slider/Circle.png");
-	Marker = SDL_CreateTextureFromSurface(renderer, temp);
-	SDL_FreeSurface(temp);
-
 	this->onSliderValueChanged = onSliderValueChanged;
-}
-
-Slider::~Slider(){
-	//Freeing up the memory
-	SDL_DestroyTexture(Marker);
 }
 
 void Slider::SetActive(bool state) {

--- a/Slider.cpp
+++ b/Slider.cpp
@@ -3,16 +3,13 @@
 
 #include <iostream>
 
-Slider::Slider(SDL_Renderer* r, int x, int y, int Width, int Height, int minvalue, int maxvalue, int value, std::function<void()> onSliderValueChanged)
+Slider::Slider(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, int minvalue, int maxvalue, int value, std::function<void()> onSliderValueChanged)
     : Slider(r, x, y, Width, Height, top_left, minvalue, maxvalue, value, onSliderValueChanged)
 {}
 
-Slider::Slider(SDL_Renderer* r, int x, int y, int Width, int Height, Anchor anchor, int minvalue, int maxvalue, int value, std::function<void()> onSliderValueChanged)
-    : InputDrawable(anchor)
+Slider::Slider(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, Anchor anchor, int minvalue, int maxvalue, int value, std::function<void()> onSliderValueChanged)
+    : InputDrawable(anchor), renderer(r)
 {
-	//Saving a reference to the renderer
-	renderer = r;
-
 	//Initialize all variables
 	ChangeValues(minvalue, maxvalue, value);
 	ChangePosition(x, y, Width, Height);

--- a/Slider.h
+++ b/Slider.h
@@ -2,15 +2,19 @@
 #define Slider_H
 
 #pragma once
-#include <SDL.h>
-#include <functional>
 #include "Drawable.h"
+
+#include "SDL_ctx.h"
+
+#include <SDL.h>
+
+#include <functional>
 
 class Slider : public InputDrawable {
 public:
 	//Constructor, initializes the values
-	Slider(SDL_Renderer* r, int x, int y, int Width, int Height, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
-	Slider(SDL_Renderer* r, int x, int y, int Width, int Height, Anchor anchor, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
+	Slider(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
+	Slider(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, Anchor anchor, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
 
 	//Destructor, frees up the memory
 	~Slider();
@@ -42,7 +46,7 @@ protected:
 	void callOnValueChanged();
 
 	//A reference to the window's renderer
-	SDL_Renderer* renderer;
+	RendererRef renderer;
 
 	//The Slider's graphical components
 	SDL_Texture* Marker;

--- a/Slider.h
+++ b/Slider.h
@@ -16,9 +16,6 @@ public:
 	Slider(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
 	Slider(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, Anchor anchor, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
 
-	//Destructor, frees up the memory
-	~Slider();
-
 	//Handle input events
 	void HandleInput(const SDL_Event& ev) override;
 
@@ -49,7 +46,7 @@ protected:
 	RendererRef renderer;
 
 	//The Slider's graphical components
-	SDL_Texture* Marker;
+	SDL_Texture_ctx Marker;
 
 	//The rectangles of the marker and the slider
 	SDL_Rect bg_rect;

--- a/StatePreview.cpp
+++ b/StatePreview.cpp
@@ -5,7 +5,7 @@
 #include "Label.h"
 #include "Image.h"
 
-StatePreview::StatePreview(SDL_Renderer* r, int id, std::string StateName, std::string controller, PlayerController* PC, int res[8], int pop, std::string Factories[4], std::function<void()> CloseFunc, std::function<void(std::unique_ptr<Screen>, std::string)> ChangeScreenFunc) : Screen(r) {
+StatePreview::StatePreview(SDL_Renderer_ctx& r, int id, std::string StateName, std::string controller, PlayerController* PC, int res[8], int pop, std::string Factories[4], std::function<void()> CloseFunc, std::function<void(std::unique_ptr<Screen>, std::string)> ChangeScreenFunc) : Screen(r) {
         auto [Width, Height] = GetWindowDimensions();
 	Controller = controller;
 	std::string str = "Flags/" + Controller;

--- a/TextEntry.cpp
+++ b/TextEntry.cpp
@@ -3,13 +3,13 @@
 #include "Image.h"
 #include "Label.h"
 
-TextEntry::TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, std::string defaultText, int maxCharacters) : TextEntry(r, x, y, Width, Height, top_left, defaultText, maxCharacters) {
+TextEntry::TextEntry(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string defaultText, int maxCharacters) : TextEntry(r, x, y, Width, Height, top_left, defaultText, maxCharacters) {
 }
 
-TextEntry::TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, std::string defaultText, std::string hint, int maxCharacters) : TextEntry(r, x, y, Width, Height, top_left, defaultText, hint, maxCharacters) {
+TextEntry::TextEntry(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string defaultText, std::string hint, int maxCharacters) : TextEntry(r, x, y, Width, Height, top_left, defaultText, hint, maxCharacters) {
 }
 
-TextEntry::TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, int maxCharacters) {
+TextEntry::TextEntry(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, int maxCharacters) : RendererReference(r) {
     background = std::make_unique<Image>(r, "Backgrounds/FlagBg.png", x, y, Width, Height, anchor);
     textLabel = std::make_unique<Label>(r, defaultText, 20, int(x * 1.08), int(y * 1.08), anchor);
     hintLabel = NULL;
@@ -22,7 +22,7 @@ TextEntry::TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, Ancho
     this->y = y;
 }
 
-TextEntry::TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, std::string hint, int maxCharacters) : TextEntry(r, x, y, Width, Height, anchor, defaultText, maxCharacters) {
+TextEntry::TextEntry(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, std::string hint, int maxCharacters) : TextEntry(r, x, y, Width, Height, anchor, defaultText, maxCharacters) {
     ChangeHint(hint);
 }
 

--- a/TextEntry.h
+++ b/TextEntry.h
@@ -2,23 +2,24 @@
 #define BUTTON_H
 
 #pragma once
-#include <string>
+#include "Drawable.h"
+
+#include "SDL_ctx.h"
+
 #include <functional>
 #include <memory>
-#include "Drawable.h"
+#include <string>
 
 class Image;
 class Label;
 
-typedef struct SDL_Renderer SDL_Renderer;
-
 class TextEntry : public InputDrawable {
 public:
     //Constructor
-    TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, std::string defaultText, int maxCharacters = 30);
-    TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, std::string defaultText, std::string hint = "", int maxCharacters = 30);
-    TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, int maxCharacters = 30);
-    TextEntry(SDL_Renderer* r, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, std::string hint = "", int maxCharacters = 30);
+    TextEntry(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string defaultText, int maxCharacters = 30);
+    TextEntry(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string defaultText, std::string hint = "", int maxCharacters = 30);
+    TextEntry(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, int maxCharacters = 30);
+    TextEntry(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, std::string hint = "", int maxCharacters = 30);
 
     //Destructor
     ~TextEntry() = default;
@@ -57,7 +58,7 @@ protected:
     bool focused;
 
     //Reference the the screen's renderer
-    SDL_Renderer* RendererReference;
+    RendererRef RendererReference;
 
     //The components of the Entry
     std::unique_ptr<Image> background;

--- a/ToggleButton.cpp
+++ b/ToggleButton.cpp
@@ -35,8 +35,6 @@ ToggleButton::ToggleButton(SDL_Renderer_ctx& r, [[maybe_unused]]int x, [[maybe_u
 
 ToggleButton::~ToggleButton(){
     //Free up the memory
-    SDL_DestroyTexture(activeTexture);
-    SDL_DestroyTexture(inactiveTexture);
     Mix_FreeChunk(music);
 }
 
@@ -96,22 +94,9 @@ void ToggleButton::ChangeImage(std::string activeImage, std::string inactiveImag
     auto activeImagePath = activeImage + ".png";
     auto inactiveImagePath = inactiveImage + ".png";
 
-    //Destroy the textures, if they already exist
-    if (activeTexture != nullptr) {
-        SDL_DestroyTexture(activeTexture);
-    }
-    if (inactiveTexture != nullptr) {
-        SDL_DestroyTexture(inactiveTexture);
-    }
-
     //Loading the button's textures
-    SDL_Surface* img = IMG_Load(activeImagePath.c_str());
-    activeTexture = SDL_CreateTextureFromSurface(RendererReference, img);
-    SDL_FreeSurface(img);
-
-    img = IMG_Load(inactiveImagePath.c_str());
-    inactiveTexture = SDL_CreateTextureFromSurface(RendererReference, img);
-    SDL_FreeSurface(img);
+    activeTexture = SDL_Texture_ctx::IMG_Load(RendererReference, activeImagePath);
+    inactiveTexture = SDL_Texture_ctx::IMG_Load(RendererReference, inactiveImagePath);
 }
 
 void ToggleButton::ChangePosition(int x, int y, int Width, int Height){

--- a/ToggleButton.cpp
+++ b/ToggleButton.cpp
@@ -2,16 +2,13 @@
 #include <iostream>
 #include "Button.h"
 
-ToggleButton::ToggleButton(SDL_Renderer* r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, std::function<void(bool)> f, int keybind) : ToggleButton(r, x, y, Width, Height, activeImage, inactiveImage, top_left, f, keybind) {
+ToggleButton::ToggleButton(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, std::function<void(bool)> f, int keybind) : ToggleButton(r, x, y, Width, Height, activeImage, inactiveImage, top_left, f, keybind) {
 }
 
-ToggleButton::ToggleButton(SDL_Renderer* r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, bool val, std::function<void(bool)> f, int keybind) : ToggleButton(r, x, y, Width, Height, activeImage, inactiveImage, top_left, val, f, keybind) {
+ToggleButton::ToggleButton(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, bool val, std::function<void(bool)> f, int keybind) : ToggleButton(r, x, y, Width, Height, activeImage, inactiveImage, top_left, val, f, keybind) {
 }
 
-ToggleButton::ToggleButton(SDL_Renderer* r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, Anchor anchor, std::function<void(bool)> f, int keybind) : InputDrawable(anchor) {
-    //Saving the renderer's reference
-    RendererReference = r;
-
+ToggleButton::ToggleButton(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, Anchor anchor, std::function<void(bool)> f, int keybind) : InputDrawable(anchor), RendererReference(r) {
     //Set the default values
     bHovered = false;
     value = false;
@@ -32,7 +29,7 @@ ToggleButton::ToggleButton(SDL_Renderer* r, int x, int y, int Width, int Height,
     music = Mix_LoadWAV("Sounds/ButtonClick.mp3");
 }
 
-ToggleButton::ToggleButton([[maybe_unused]]SDL_Renderer* r, [[maybe_unused]]int x, [[maybe_unused]]int y, [[maybe_unused]]int Width, [[maybe_unused]]int Height, [[maybe_unused]]std::string activeImage, [[maybe_unused]]std::string inactiveImage, [[maybe_unused]]Anchor anchor, [[maybe_unused]]bool val, [[maybe_unused]]std::function<void(bool)> f, [[maybe_unused]]int keybind) {
+ToggleButton::ToggleButton(SDL_Renderer_ctx& r, [[maybe_unused]]int x, [[maybe_unused]]int y, [[maybe_unused]]int Width, [[maybe_unused]]int Height, [[maybe_unused]]std::string activeImage, [[maybe_unused]]std::string inactiveImage, [[maybe_unused]]Anchor anchor, [[maybe_unused]]bool val, [[maybe_unused]]std::function<void(bool)> f, [[maybe_unused]]int keybind) : RendererReference(r) {
     value = val;
 }
 

--- a/ToggleButton.h
+++ b/ToggleButton.h
@@ -2,20 +2,24 @@
 #define TOGGLEBUTTON_H
 
 #pragma once
+#include "Drawable.h"
+
+#include "SDL_ctx.h"
+
 #include <SDL.h>
-#include <string>
-#include <functional>
 #include <SDL_image.h>
 #include <SDL_mixer.h>
-#include "Drawable.h"
+
+#include <string>
+#include <functional>
 
 class ToggleButton : public InputDrawable {
 public:
     //Constructor
-    ToggleButton(SDL_Renderer* r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, std::function<void(bool)> f = {}, int keybind = 0);
-    ToggleButton(SDL_Renderer* r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, bool val, std::function<void(bool)> f = {}, int keybind = 0);
-    ToggleButton(SDL_Renderer* r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, Anchor anchor, std::function<void(bool)> f = {}, int keybind = 0);
-    ToggleButton(SDL_Renderer* r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, Anchor anchor, bool val, std::function<void(bool)> f = {}, int keybind = 0);
+    ToggleButton(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, std::function<void(bool)> f = {}, int keybind = 0);
+    ToggleButton(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, bool val, std::function<void(bool)> f = {}, int keybind = 0);
+    ToggleButton(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, Anchor anchor, std::function<void(bool)> f = {}, int keybind = 0);
+    ToggleButton(SDL_Renderer_ctx& r, int x, int y, int Width, int Height, std::string activeImage, std::string inactiveImage, Anchor anchor, bool val, std::function<void(bool)> f = {}, int keybind = 0);
 
     //Destructor
     ~ToggleButton();
@@ -73,7 +77,7 @@ protected:
     SDL_Rect draw_rect;
 
     //Reference the the screen's renderer
-    SDL_Renderer* RendererReference;
+    RendererRef RendererReference;
 
     //Reference to the button's texture
     SDL_Texture* activeTexture = nullptr;

--- a/ToggleButton.h
+++ b/ToggleButton.h
@@ -80,8 +80,8 @@ protected:
     RendererRef RendererReference;
 
     //Reference to the button's texture
-    SDL_Texture* activeTexture = nullptr;
-    SDL_Texture* inactiveTexture = nullptr;
+    SDL_Texture_ctx activeTexture;
+    SDL_Texture_ctx inactiveTexture;
 
     //The button's onClick sound
     Mix_Chunk* music = nullptr;

--- a/TradeScreen.cpp
+++ b/TradeScreen.cpp
@@ -1,6 +1,6 @@
 #include "ScreenList.h"
 
-TradeScreen::TradeScreen(SDL_Renderer* r, Country* Pl) : Screen(r) {
+TradeScreen::TradeScreen(SDL_Renderer_ctx& r, Country* Pl) : Screen(r) {
 	SetupBg("Backgrounds/Industry.png");
 	Player = Pl;
 }

--- a/UI.cpp
+++ b/UI.cpp
@@ -9,7 +9,7 @@
 #include "ScreenList.h"
 #include "ToggleButton.h"
 
-UI::UI(SDL_Renderer* r, const char* tag, PlayerController* PC, std::function<void(std::unique_ptr<Screen>, std::string)> fpl), renderer(r) {
+UI::UI(SDL_Renderer_ctx& r, const char* tag, PlayerController* PC, std::function<void(std::unique_ptr<Screen>, std::string)> fpl) : renderer(r) {
         auto [Width, Height] = GetWindowDimensions();
 
 	//The country management tabs

--- a/UI.h
+++ b/UI.h
@@ -5,7 +5,10 @@
 
 #include "ToggleButton.h"
 
+#include "SDL_ctx.h"
+
 #include <SDL.h>
+
 #include <array>
 #include <functional>
 #include <memory>
@@ -21,11 +24,11 @@ class PlayerController;
 class UI {
 public:
     //Constructor
-    UI(SDL_Renderer* r, const char* tag, PlayerController* PC, std::function<void(std::unique_ptr<Screen>, std::string)> fpl = nullptr);
+    UI(SDL_Renderer_ctx& r, const char* tag, PlayerController* PC, std::function<void(std::unique_ptr<Screen>, std::string)> fpl = nullptr);
     ~UI() = default;
 
     //This is a reference to the main window's renderer
-    SDL_Renderer* renderer;
+    RendererRef renderer;
 
     //Stores the main window's dimensions
     int WindowSize[2];


### PR DESCRIPTION
As a first step towards getting rid of pointers to SDL struct instances and replacing them with instances of SDL RAII classes with member functions that can perform misc. SDL operations, all classes wanting an `SDL_Renderer*` now requires an `SDL_Renderer_ctx&`.

It'll be stored in the class using a `promiscuous_ref` which can implicitly convert to `SDL_Renderer*` or `SDL_Renderer_ctx&`.

---

Yet another big change so you'd better take a look at it first :-)