### PR TITLE
Added texture caching.

### DIFF
--- a/SDL_ctx.cpp
+++ b/SDL_ctx.cpp
@@ -90,7 +90,7 @@ SDL_Texture* SDL_Texture_ctx::operator->() { return texture.get(); }
 SDL_Texture_ctx::operator SDL_Texture* () { return texture.get(); }
 
 SDL_Texture_ctx::SDL_Texture_ctx(SDL_Renderer_ctx& r, SDL_Texture_ctx& t) : 
-    texture(t.texture.get(), nullptr) {
+    texture(t.texture.get(), &SDL_DestroyTexture) {
 }
 
 SDL_Texture_ctx SDL_Texture_ctx::IMG_Load(SDL_Renderer_ctx& r, std::string_view filename) {

--- a/SDL_ctx.h
+++ b/SDL_ctx.h
@@ -176,7 +176,7 @@ public:
 
     static SDL_Texture_ctx IMG_Load(SDL_Renderer_ctx& r, std::string_view filename);
 private:
-    std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)> texture;
+    std::shared_ptr<SDL_Texture> texture;
 
     SDL_Texture_ctx(SDL_Renderer_ctx&, SDL_Texture_ctx&);
 

--- a/SDL_ctx.h
+++ b/SDL_ctx.h
@@ -7,6 +7,7 @@
 #include <SDL_ttf.h>
 
 #include <memory>
+#include <unordered_map>
 #include <string_view>
 
 /*-----------------------------------------------------------------------------
@@ -176,6 +177,10 @@ public:
     static SDL_Texture_ctx IMG_Load(SDL_Renderer_ctx& r, std::string_view filename);
 private:
     std::unique_ptr<SDL_Texture, decltype(&SDL_DestroyTexture)> texture;
+
+    SDL_Texture_ctx(SDL_Renderer_ctx&, SDL_Texture_ctx&);
+
+    static std::unordered_map<std::string, SDL_Texture_ctx> textureCache;
 };
 //-----------------------------------------------------------------------------
 class TTF_Font_ctx {


### PR DESCRIPTION
Added a `static std::unordered_map<std::string, SDL_Texture_ctx>` in `SDL_Texture_ctx` that caches the textures loaded from memory. If the code tries to load an image that has already been cached, then we return a 'SDL_Texture_ctx' object that has no deleter in it's `std::unique_ptr`. Created a PR in order to check the code before we commit it.