### PR TITLE
Fix race conditions

### DIFF
--- a/DiplomacyScreen.cpp
+++ b/DiplomacyScreen.cpp
@@ -14,9 +14,9 @@ DiplomacyScreen::DiplomacyScreen(MainWindow& mw, PlayerController* PC, std::stri
 
     AddImage<Image>(*main_window, "Backgrounds/old_paper.png", int(Width * 0.4), int(Height * 0.2), int(Width * 0.5), int(Height * 0.6));
 
-	AddImage<Image>(*main_window, "Flags/" + targetTag + ".png", int(Width * 0.4), int(Height * 0.2), 120, 80);
-	AddImage<Image>(*main_window, "Icons/population.png", int(Width * 0.43), int(Height * 0.3), int(Width * 0.027), int(Height * 0.048));
-	AddImage<Image>(*main_window, "Icons/flags.png", int(Width * 0.77), int(Height * 0.225), int(Width * 0.027), int(Height * 0.048));
+    AddImage<Image>(*main_window, "Flags/" + targetTag + ".png", int(Width * 0.4), int(Height * 0.2), 120, 80);
+    AddImage<Image>(*main_window, "Icons/population.png", int(Width * 0.43), int(Height * 0.3), int(Width * 0.027), int(Height * 0.048));
+    AddImage<Image>(*main_window, "Icons/flags.png", int(Width * 0.77), int(Height * 0.225), int(Width * 0.027), int(Height * 0.048));
 
     CreateCountryButtons(PC, targetTag);
 
@@ -24,17 +24,17 @@ DiplomacyScreen::DiplomacyScreen(MainWindow& mw, PlayerController* PC, std::stri
     AddLabel<Label>(*main_window, std::to_string(PC->CountriesArr[selectedCountryIndex]->GetPopulation()), 24, int(Width * 0.465), int(Height * 0.31));
     AddLabel<Label>(*main_window, "N/A", 28, int(Width * 0.8), int(Height * 0.225));
 
-	AddDrawable<Button>(*main_window, int(Width * 0.4275), int(Height * 0.5), int(Width * 0.13), int(Height * 0.04), "Declare War", fontSize);
-	AddDrawable<Button>(*main_window, int(Width * 0.4275), int(Height * 0.58), int(Width * 0.13), int(Height * 0.04), "Make Demands", fontSize);
-	AddDrawable<Button>(*main_window, int(Width * 0.4275), int(Height * 0.66), int(Width * 0.13), int(Height * 0.04), "Justify Claim", fontSize);
-	AddDrawable<Button>(*main_window, int(Width * 0.585), int(Height * 0.5), int(Width * 0.13), int(Height * 0.04), "Form Alliance", fontSize, [this]{ SendAllianceRequest();});
-	AddDrawable<Button>(*main_window, int(Width * 0.585), int(Height * 0.58), int(Width * 0.13), int(Height * 0.04), "Non-Aggression Pact", fontSize);
-	AddDrawable<Button>(*main_window, int(Width * 0.585), int(Height * 0.66), int(Width * 0.13), int(Height * 0.04), "Improve Relations", fontSize, [this] { ImproveRelations(); });
-	AddDrawable<Button>(*main_window, int(Width * 0.585), int(Height * 0.74), int(Width * 0.13), int(Height * 0.04), "Worsen Relations", fontSize, [this] { WorsenRelations(); });
-	AddDrawable<Button>(*main_window, int(Width * 0.7425), int(Height * 0.5), int(Width * 0.13), int(Height * 0.04), "Trade Deal", fontSize);
-	AddDrawable<Button>(*main_window, int(Width * 0.7425), int(Height * 0.58), int(Width * 0.13), int(Height * 0.04), "Embargo", fontSize, [this] { ImposeEmbargo(); });
-	AddDrawable<Button>(*main_window, int(Width * 0.7425), int(Height * 0.66), int(Width * 0.13), int(Height * 0.04), "Request Access", fontSize);
-	AddDrawable<Button>(*main_window, int(Width * 0.7425), int(Height * 0.74), int(Width * 0.13), int(Height * 0.04), "Provide Access", fontSize);
+    AddDrawable<Button>(*main_window, int(Width * 0.4275), int(Height * 0.5), int(Width * 0.13), int(Height * 0.04), "Declare War", fontSize);
+    AddDrawable<Button>(*main_window, int(Width * 0.4275), int(Height * 0.58), int(Width * 0.13), int(Height * 0.04), "Make Demands", fontSize);
+    AddDrawable<Button>(*main_window, int(Width * 0.4275), int(Height * 0.66), int(Width * 0.13), int(Height * 0.04), "Justify Claim", fontSize);
+    AddDrawable<Button>(*main_window, int(Width * 0.585), int(Height * 0.5), int(Width * 0.13), int(Height * 0.04), "Form Alliance", fontSize, [this]{ SendAllianceRequest();});
+    AddDrawable<Button>(*main_window, int(Width * 0.585), int(Height * 0.58), int(Width * 0.13), int(Height * 0.04), "Non-Aggression Pact", fontSize);
+    AddDrawable<Button>(*main_window, int(Width * 0.585), int(Height * 0.66), int(Width * 0.13), int(Height * 0.04), "Improve Relations", fontSize, [this] { ImproveRelations(); });
+    AddDrawable<Button>(*main_window, int(Width * 0.585), int(Height * 0.74), int(Width * 0.13), int(Height * 0.04), "Worsen Relations", fontSize, [this] { WorsenRelations(); });
+    AddDrawable<Button>(*main_window, int(Width * 0.7425), int(Height * 0.5), int(Width * 0.13), int(Height * 0.04), "Trade Deal", fontSize);
+    AddDrawable<Button>(*main_window, int(Width * 0.7425), int(Height * 0.58), int(Width * 0.13), int(Height * 0.04), "Embargo", fontSize, [this] { ImposeEmbargo(); });
+    AddDrawable<Button>(*main_window, int(Width * 0.7425), int(Height * 0.66), int(Width * 0.13), int(Height * 0.04), "Request Access", fontSize);
+    AddDrawable<Button>(*main_window, int(Width * 0.7425), int(Height * 0.74), int(Width * 0.13), int(Height * 0.04), "Provide Access", fontSize);
 
     PCref = PC;
 

--- a/GameScreen.cpp
+++ b/GameScreen.cpp
@@ -31,26 +31,26 @@ GameScreen::GameScreen(MainWindow& mw, const char* tag,  std::function<void()> f
 }
 
 void GameScreen::Pause() {
-	if (StateViewingScreen) {
-		CloseScreenPreview();
-		//overlay->Buttons[0]->Playsound();
-	} else if (bHasActiveScreen() == true){
-		CloseActiveScreen();
-		overlay->Buttons[0]->Playsound();
-	} else {
-		if (bIsPaused == true) {
-			bIsPaused = false;
-                        PM.reset();
-		}
-		else {
-			PM = std::make_unique<PauseMenu>(*main_window, QuitFunc, [this]{ Pause(); }, ChangeScreenFunc);
-			bIsPaused = true;
-			if (PC->Date.bIsPaused == false) {
-				overlay->PauseDate(true);
-			}
-			overlay->Buttons[0]->Playsound();
-		}
-	}
+    if (StateViewingScreen) {
+        CloseScreenPreview();
+        //overlay->Buttons[0]->Playsound();
+    } else if (bHasActiveScreen() == true){
+        CloseActiveScreen();
+        overlay->Buttons[0]->Playsound();
+    } else {
+        if (bIsPaused == true) {
+            bIsPaused = false;
+            PM.reset();
+        }
+        else {
+            PM = std::make_unique<PauseMenu>(*main_window, QuitFunc, [this]{ Pause(); }, ChangeScreenFunc);
+            bIsPaused = true;
+            if (PC->bIsPaused == false) {
+                overlay->PauseDate(true);
+            }
+            overlay->Buttons[0]->Playsound();
+        }
+    }
 }
 
 void GameScreen::RenderBackground() {

--- a/PlayerController.cpp
+++ b/PlayerController.cpp
@@ -3,7 +3,6 @@
 #include "SDL_ColorDetection.h"
 
 #include <SDL_image.h>
-#include <SDL_thread.h>
 
 #include <vector>
 #include <fstream>
@@ -32,204 +31,194 @@ std::vector<T> LoadFromFile(const char* filename) {
 } // namesapce
 
 PlayerController::PlayerController(SDL_Renderer_ctx& r, const char* tag) : RendererReference(r) {
-	//Save the player's country tag
-	player_tag = tag;
+    //Save the player's country tag
+    player_tag = tag;
 
-	//Create the map on a separate thread
-	SDL_Thread* MapThread = SDL_CreateThread(&PlayerController::LoadMap, nullptr, this);
-	SDL_Thread* AssetsThread = SDL_CreateThread(&PlayerController::LoadUtilityAssets, nullptr, this);
+    //Create the map and assets in separate threads
+    auto MapThread = std::jthread(&PlayerController::LoadMap, this);
+    auto AssetsThread = std::jthread(&PlayerController::LoadUtilityAssets, this);
 
-	//Load the Countries' Names
-	auto countryNames = LoadFromFile<std::string, Line>("map/Countries/CountryNames.txt");
+    //Load the Countries' Names
+    auto countryNames = LoadFromFile<std::string, Line>("map/Countries/CountryNames.txt");
 
-	//Load the country tags
-	auto tags = LoadFromFile<std::string, Line>("map/Countries/CountryTags.txt");
+    //Load the country tags
+    auto tags = LoadFromFile<std::string, Line>("map/Countries/CountryTags.txt");
 
-	//Load the countries' budget at the start of the game
-	auto balance = LoadFromFile<int>("map/Countries/CountryBalances.txt");
+    //Load the countries' budget at the start of the game
+    auto balance = LoadFromFile<int>("map/Countries/CountryBalances.txt");
 
     if(countryNames.size() != tags.size() || countryNames.size() != balance.size()) {
         std::cerr << "Country data mismatch " << countryNames.size() << ',' << tags.size() << ',' << balance.size() << std::endl;
         std::terminate();
     }
 
-	//Load all state names
-	auto stateNames = LoadFromFile<std::string, Line>("map/States/StateNames.txt");
+    //Load all state names
+    auto stateNames = LoadFromFile<std::string, Line>("map/States/StateNames.txt");
 
-	//Load all state owner tags
-	auto owners = LoadFromFile<std::string, Line>("map/States/StateOwners.txt");
+    //Load all state owner tags
+    auto owners = LoadFromFile<std::string, Line>("map/States/StateOwners.txt");
 
-	//Load all the states' unique color IDs
-	auto colors = LoadFromFile<Color>("map/States/StateColors.txt");
+    //Load all the states' unique color IDs
+    auto colors = LoadFromFile<Color>("map/States/StateColors.txt");
 
-	//Load all the state's coordinates
-	auto coords = LoadFromFile<Coordinate>("map/States/StateCoordinates.txt");
+    //Load all the state's coordinates
+    auto coords = LoadFromFile<Coordinate>("map/States/StateCoordinates.txt");
 
-	//Load all the state's populations
-	auto populations = LoadFromFile<int>("map/States/StatePopulations.txt");
+    //Load all the state's populations
+    auto populations = LoadFromFile<int>("map/States/StatePopulations.txt");
 
     if(stateNames.size() != owners.size() || stateNames.size() != colors.size() || stateNames.size() != coords.size() || stateNames.size() != populations.size()) {
         std::cerr << "State data mismatch " << stateNames.size() << ',' << owners.size() << ',' << colors.size() << ',' << coords.size() << ',' << populations.size() << std::endl;
         std::terminate();
     }
 
-	//Create all countries
-	InitializeCountries(countryNames, tags, tag, balance);
+    //Create all countries
+    InitializeCountries(countryNames, tags, tag, balance);
 
-	//Create all the states
-	InitializeStates(owners, stateNames, coords, populations, colors);
+    //Create all the states
+    InitializeStates(owners, stateNames, coords, populations, colors);
 
-	//Initialize the date
-	Date = { .Year = 1910, .Month = 1, .Day = 1, .Speed = 1, .bIsPaused = true, .MonthDays = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31} };
-
-	//Wait for the map to be loaded
-	SDL_WaitThread(AssetsThread, nullptr);
-	SDL_WaitThread(MapThread, nullptr);
+    //Initialize the date
+    Date = { .Year = 1910, .Month = 1, .Day = 1, .Speed = 1, .MonthDays = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31} };
 }
 
 PlayerController::~PlayerController() {
-	//Stop the date thread if the game is not paused
-	if (Date.bIsPaused == false) {
-		Pause();
-	}
+    //Stop the date thread if the game is not paused
+    if (bIsPaused == false) {
+        Pause();
+    }
 }
 
-int PlayerController::LoadMap(void* pc){
-	PlayerController& PC = *static_cast<PlayerController*>(pc);
+void PlayerController::LoadMap(){
+    map = SDL_Surface_ctx::IMG_Load("map/1910.png");
+    SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0, 0, 0, 0));
 
-	PC.map = SDL_Surface_ctx::IMG_Load("map/1910.png");
-	SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0, 0, 0, 0));
+    SDL_Rect strect = { .x = 232, .y = 0, .w = 5616 , .h = 2160 };
+    SDL_BlitSurface(map, &strect, base, NULL);
+    strect = { .x = -5616 + 232, .y = 0, .w = 5616 * 2 , .h = 2160 };
+    SDL_BlitSurface(map, &strect, base, NULL);
+    strect = { .x = -5616 * 2 + 232, .y = 0, .w = 5616 * 3 , .h = 2160 };
+    SDL_BlitSurface(map, &strect, base, NULL);
 
-	SDL_Rect strect = { .x = 232, .y = 0, .w = 5616 , .h = 2160 };
-	SDL_BlitSurface(PC.map, &strect, base, NULL);
-	strect = { .x = -5616 + 232, .y = 0, .w = 5616 * 2 , .h = 2160 };
-	SDL_BlitSurface(PC.map, &strect, base, NULL);
-	strect = { .x = -5616 * 2 + 232, .y = 0, .w = 5616 * 3 , .h = 2160 };
-	SDL_BlitSurface(PC.map, &strect, base, NULL);
-
-	PC.txt = SDL_Texture_ctx(PC.RendererReference, base);
-
-	return 0;
+    txt = SDL_Texture_ctx(RendererReference, base);
 }
 
-int PlayerController::LoadUtilityAssets(void* pc){
-	PlayerController& PC = *static_cast<PlayerController*>(pc);
+void PlayerController::LoadUtilityAssets(){
+    provinces = SDL_Surface_ctx::IMG_Load("map/provinces.bmp");
 
-	PC.provinces = SDL_Surface_ctx::IMG_Load("map/provinces.bmp");
-
-	SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000));
-	PC.overlay = SDL_Texture_ctx(PC.RendererReference, base);
-
-	return 0;
+    SDL_Surface_ctx base(SDL_CreateRGBSurface(0, 16383, 2160, 32, 0xff, 0xff00, 0xff0000, 0xff000000));
+    overlay = SDL_Texture_ctx(RendererReference, base);
 }
 
 void PlayerController::InitializeCountries(std::vector<std::string>& names, std::vector<std::string>& tags, const char* tag, std::vector<int>& balance){
-	int Res[31] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1000 };
+    int Res[31] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1000 };
 
-	for (unsigned x = 0; x < tags.size(); x++) {
-		Res[30] = balance[x];
-		CountriesArr.push_back(std::make_unique<Country>(tags[x], names[x], 0, 0, 0, Res));
-		if (tag == tags[x]) {
-			player_index = x;
-		}
-	}
+    for (unsigned x = 0; x < tags.size(); x++) {
+        Res[30] = balance[x];
+        CountriesArr.push_back(std::make_unique<Country>(tags[x], names[x], 0, 0, 0, Res));
+        if (tag == tags[x]) {
+            player_index = x;
+        }
+    }
 
-	for (unsigned c1 = 0; c1 < CountriesArr.size(); c1++) {
-		for (unsigned c2 = c1 + 1; c2 < CountriesArr.size(); c2++) {
-			diplo.relations.emplace(CountryPair{CountriesArr[c1].get(), CountriesArr[c2].get()}, Relation{100});
-		}
-	}
+    for (unsigned c1 = 0; c1 < CountriesArr.size(); c1++) {
+        for (unsigned c2 = c1 + 1; c2 < CountriesArr.size(); c2++) {
+            diplo.relations.emplace(CountryPair{CountriesArr[c1].get(), CountriesArr[c2].get()}, Relation{100});
+        }
+    }
 }
 
 void PlayerController::InitializeStates(std::vector<std::string>& owners, std::vector<std::string>& names, std::vector<Coordinate>& coords, const std::vector<int>& populations, std::vector<Color>& colors){
-	short int res[8] = { 50, 50, 50, 50, 50, 50, 50, 50 };
-	int target = 0;
+    short int res[8] = { 50, 50, 50, 50, 50, 50, 50, 50 };
+    int target = 0;
 
-        StatesArr.reserve(populations.size());
-	for (unsigned x = 0; x < owners.size(); ++x) {
-		for (unsigned y = 0; y < CountriesArr.size(); y++) {
-			if (owners[x] == CountriesArr[y]->GetTag()) {
-				target = y;
-				break;
-			}
-		}
+    StatesArr.reserve(populations.size());
+    for (unsigned x = 0; x < owners.size(); ++x) {
+        for (unsigned y = 0; y < CountriesArr.size(); y++) {
+            if (owners[x] == CountriesArr[y]->GetTag()) {
+                target = y;
+                break;
+            }
+        }
 
-                StatesArr.emplace_back(names[x], x + 1, owners[x], owners[x], populations[x], coords[x], colors[x], res, &CountriesArr.at(target)->Stock);
+        StatesArr.emplace_back(names[x], x + 1, owners[x], owners[x], populations[x], coords[x], colors[x], res, &CountriesArr.at(target)->Stock);
 
-		StatesMap.insert(std::pair(StatesArr.back().color.toString(), &StatesArr.back()));
+        StatesMap.insert(std::pair(StatesArr.back().color.toString(), &StatesArr.back()));
 
-		CountriesArr.at(target)->AddState(&StatesArr.back());
-	}
+        CountriesArr.at(target)->AddState(&StatesArr.back());
+    }
 }
 
-int PlayerController::AdvanceDate(void* ref){
-	PlayerController* reference = static_cast<PlayerController*>(ref);
+void PlayerController::AdvanceDate(){
+    while (bIsPaused == false) {
+        for (int i = 0; i < 10 && bIsPaused == false; i++) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(260 - Date.Speed * 60));
+        }
 
-	while (true) {
-		for (int i = 0; i < 10 && reference->Date.bIsPaused == false; i++) {
-			std::this_thread::sleep_for(std::chrono::milliseconds(260 - reference->Date.Speed * 60));
-		}
+        //Stop if the game is paused
+        if (bIsPaused) {
+            return;
+        }
 
-		//Stop if the game is paused
-		if (reference->Date.bIsPaused) {
-			return 0;
-		}
+        //Advance by one day
+        Date.Day++;
 
-		//Advance by one day
-		reference->Date.Day++;
+        //Execute the tick function
+        Tick();
 
-		//Execute the tick function
-		reference->Tick();
+        //Check whether the month has changed
+        if (Date.Day == Date.MonthDays[Date.Month - 1] + 1) {
+            Date.Month++;
+            Date.Day = 1;
 
-		//Check whether the month has changed
-		if (reference->Date.Day == reference->Date.MonthDays[reference->Date.Month - 1] + 1) {
-			reference->Date.Month++;
-			reference->Date.Day = 1;
+            //Check whether the year has changed
+            if (Date.Month == 13) {
+                Date.Year++;
+                Date.Month = 1;
 
-			//Check whether the year has changed
-			if (reference->Date.Month == 13) {
-				reference->Date.Year++;
-				reference->Date.Month = 1;
-
-				//Check whether the current year is a leap year
-				if (reference->Date.Year % 4 == 0) {
-					reference->Date.MonthDays[1] = 29;
-				} else {
-					reference->Date.MonthDays[1] = 28;
-				}
-			}
-		}
-	}
+                //Check whether the current year is a leap year
+                if (Date.Year % 4 == 0) {
+                    Date.MonthDays[1] = 29;
+                } else {
+                    Date.MonthDays[1] = 28;
+                }
+            }
+        }
+    }
 }
 
 void PlayerController::Pause(){
-	/*Pause or unpause the game when this function is executed.
-	It will always change the state of the Date.bIsPaused and
-	set it to the opposite value.*/
-	if (Date.bIsPaused) {
-		Date.bIsPaused = false;
-		//Create a new thread that will be running the AdvanceDate function in parallel with everything else
-		thread = SDL_CreateThread(&PlayerController::AdvanceDate, NULL, this);
-	} else {
-		Date.bIsPaused = true;
-		//Wait until the date thread has stopped execution
-		SDL_WaitThread(thread, nullptr);
-	}
+    /*Pause or unpause the game when this function is executed.
+    It will always change the state of the Date.bIsPaused and
+    set it to the opposite value.*/
+
+    if (bIsPaused) {
+        bIsPaused = false;
+        //Create a new thread that will be running the AdvanceDate function in parallel with everything else
+        std::cerr << "PlayerController::Pause: Starting thread\n";
+        thread = std::jthread(&PlayerController::AdvanceDate, this);
+    } else {
+        bIsPaused = true;
+        //Wait until the date thread has stopped execution
+        std::cerr << "PlayerController::Pause: Waiting for thread\n";
+        thread.join();
+        std::cerr << "PlayerController::Pause: Thread done\n";
+    }
 }
 
 void PlayerController::ChangeSpeed(bool change){
-	//If change is true then we increase the speed and
-	//if it is false it decreases the speed
-	if (change && Date.Speed < 4) {
-		Date.Speed++;
-	} else if (!change && Date.Speed > 1) {
-		Date.Speed--;
-	}
+    //If change is true then we increase the speed and
+    //if it is false it decreases the speed
+    if (change && Date.Speed < 4) {
+        Date.Speed++;
+    } else if (!change && Date.Speed > 1) {
+        Date.Speed--;
+    }
 }
 
 void PlayerController::Tick(){
-	//Execute the tick function for all countries (and all states)
-	for (auto& i : CountriesArr) {
-		i->Tick();
-	}
+    //Execute the tick function for all countries (and all states)
+    for (auto& i : CountriesArr) {
+        i->Tick();
+    }
 }

--- a/PlayerController.h
+++ b/PlayerController.h
@@ -11,74 +11,77 @@
 #include <SDL.h>
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <memory>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
 class PlayerController {
 public:
-	//Constructor
-	PlayerController(SDL_Renderer_ctx& r, const char* tag);
+    //Constructor
+    PlayerController(SDL_Renderer_ctx& r, const char* tag);
 
     ~PlayerController();
 
 private:
-	//Loading data functions
-	void InitializeCountries(std::vector<std::string>& names, std::vector<std::string>& tags, const char* tag, std::vector<int>& balance);
-	void InitializeStates(std::vector<std::string>& owners, std::vector<std::string>& names, std::vector<Coordinate>& coords, const std::vector<int>& populations, std::vector<Color>& colors);
+    //Loading data functions
+    void InitializeCountries(std::vector<std::string>& names, std::vector<std::string>& tags, const char* tag, std::vector<int>& balance);
+    void InitializeStates(std::vector<std::string>& owners, std::vector<std::string>& names, std::vector<Coordinate>& coords, const std::vector<int>& populations, std::vector<Color>& colors);
 
-	static int LoadMap(void*);
-	static int LoadUtilityAssets(void*);
+    void LoadMap();
+    void LoadUtilityAssets();
 	
 public:
 
-	//Some info about the player
-	std::string player_tag;
-	int player_index;
+    //Some info about the player
+    std::string player_tag;
+    int player_index;
 
-	//The in-game date
-	struct {
-		int Year;
-		int Month;
-		int Day;
-		int Speed;
-		bool bIsPaused;
-		int MonthDays[12];
-	} Date;
+    //The in-game date
+    struct {
+        int Year;
+        int Month;
+        int Day;
+        int Speed;
+        int MonthDays[12];
+    } Date;
 
-	//This is the representing the pass of a single day
-	void Tick();
+    std::atomic<bool> bIsPaused{true};
 
-	//Advances the date by one day
-	static int AdvanceDate(void* ref);
+    //This is the representing the pass of a single day
+    void Tick();
 
-	//Pauses the flow of time
-	void Pause();
+    //Advances the date by one day
+    void AdvanceDate();
 
-	//Changes the game speed
-	void ChangeSpeed(bool change);
+    //Pauses the flow of time
+    void Pause();
 
-	Market WorldMarket;
+    //Changes the game speed
+    void ChangeSpeed(bool change);
 
-	//Reference to every single state on the map
-	std::vector<State> StatesArr;
-	std::unordered_map<std::string, State*> StatesMap;
+    Market WorldMarket;
 
-	//Reference to every country
-	std::vector<std::unique_ptr<Country>> CountriesArr;
+    //Reference to every single state on the map
+    std::vector<State> StatesArr;
+    std::unordered_map<std::string, State*> StatesMap;
 
-	//The state of the diplomatic relations between every country
-	Diplomacy diplo;
+    //Reference to every country
+    std::vector<std::unique_ptr<Country>> CountriesArr;
 
-	//Some SDL assets needed
-	RendererRef RendererReference;
-	SDL_Texture_ctx txt;
-	SDL_Texture_ctx overlay;
-	SDL_Surface_ctx map;
-	SDL_Surface_ctx provinces;
+    //The state of the diplomatic relations between every country
+    Diplomacy diplo;
 
-	//Used to run the time-functionality of the game
-	SDL_Thread* thread;
+    //Some SDL assets needed
+    RendererRef RendererReference;
+    SDL_Texture_ctx txt;
+    SDL_Texture_ctx overlay;
+    SDL_Surface_ctx map;
+    SDL_Surface_ctx provinces;
+
+    //Used to run the time-functionality of the game
+    std::jthread thread;
 };
 #endif


### PR DESCRIPTION
There are currently three extra threads started by the application. None do synchronization between the threads so there are race conditions.

I've replaced the threads with `std::jthread`s which can be used to start a thread in a member function (unlike `SDL_CreateThread`).

`bIsPaused` is made into a `std::atomic<bool>` and moved out of the `Date` struct.

No further synchronization work has been done - but it's needed.

One positive effect is that the memory leaks are now very small due to the auto-joining feature of the `std::jthread`. For me, 200 bytes are leaked which is likely unavoidable due to SDL internals. Perhaps https://github.com/PanosPetras/The_Great_War/issues/1 can be closed.

Note: This has no impact on https://github.com/PanosPetras/The_Great_War/issues/10
