### PR TITLE
Fix some clang complaints

### DIFF
--- a/Button.h
+++ b/Button.h
@@ -29,7 +29,7 @@ public:
     Button(MainWindow& mw, int x, int y, int Width, int Height, std::string text, int textSize, Anchor anchor, std::function<void(void*)> f, void* arg, int keybind = 0);
 
     //Destructor
-    ~Button();
+    ~Button() override;
 
     //Called when received input, to check whether the click was in this button
     void HandleInput(const SDL_Event& ev) override;

--- a/Checkbox.h
+++ b/Checkbox.h
@@ -17,9 +17,6 @@ public:
 	//Constructor
 	Checkbox(SDL_Renderer_ctx& r, int x, int y, int Height, std::string text, int textSize, Anchor anchor, std::function<void(bool)> f, int keybind = 0);
 
-	//Destructor
-	~Checkbox() = default;
-
 	//Called when received input, to check whether the click was in this button
 	void HandleInput(const SDL_Event& ev) override;
 

--- a/Color.cpp
+++ b/Color.cpp
@@ -1,16 +1,9 @@
 #include "Color.h"
 
+#include "Eater.h"
+
 #include <iomanip>
 #include <sstream>
-
-template<char Ch>
-struct Eater {
-    friend std::istream& operator>>(std::istream& is, const Eater&) {
-        if(is.peek() != Ch) is.setstate(std::ios::failbit);
-        else is.ignore();
-        return is;
-    }
-};
 
 std::string Color::toString() const {
     std::ostringstream os;
@@ -24,14 +17,14 @@ Color::operator SDL_Color () const noexcept {
 }
 
 
-bool is_fit(int x) { return x >= 0 && x <= 0xFF; }
+inline bool is_fit(int x) { return x >= 0 && x <= 0xFF; }
 
 std::istream& operator>>(std::istream& is, Color& c) {
     Eater<'-'> hyphen;
     if(int R, G, B; is >> R >> hyphen >> G >> hyphen >> B >> Eater<'\n'>{} && is_fit(R) && is_fit(G) && is_fit(B) ) {
-        c.r = R;
-        c.g = G;
-        c.b = B;
+        c.r = static_cast<Uint8>(R);
+        c.g = static_cast<Uint8>(G);
+        c.b = static_cast<Uint8>(B);
     } else is.setstate(std::ios::failbit);
     return is;
 }

--- a/Coordinate.cpp
+++ b/Coordinate.cpp
@@ -1,17 +1,21 @@
 #include "Coordinate.h"
 
+#include "Eater.h"
+
+#include <sstream>
 #include <string>
+#include <utility>
 
 std::istream& operator>>(std::istream& is, Coordinate& c) {
     if(std::string line; std::getline(is, line)) {
         if(line == "---") {
             c.x = -1;
             c.y = -1;
-        } else if(line.size() < 11) {
-            is.setstate(std::ios::failbit);
         } else {
-            c.x = std::stoi(line.substr(0, 4));
-            c.y = std::stoi(line.substr(7, 4));
+            std::istringstream iss(std::move(line));
+            if(not(iss >> c.x >> Eater<'-','-','-'>{} >> c.y)) {
+                is.setstate(std::ios::failbit);
+            }
         }
     } else is.setstate(std::ios::failbit);
     return is;

--- a/Diplomacy.cpp
+++ b/Diplomacy.cpp
@@ -93,36 +93,32 @@ bool Relation::GetIfHasEmbargo(std::string Instigator) const {
 	return std::find(embargoes.begin(), embargoes.end(), Instigator) != embargoes.end();
 }
 
-Request::Request(RequestType id, int senderIndex, std::string senderTag, Relation& relations) : 
+Request::Request(RequestType id, unsigned senderIndex, std::string senderTag, Relation& relations) : 
     id{id}, index{senderIndex}, rel{relations}, tag(senderTag)
 {}
 
 void Request::Accept() {
-	switch (id) {
-		case alliance:
-			rel.CreateAlliance();
-			break;
-		case tradeDeal:
-			break;
-		case peaceTreaty:
-			break;
-		default:
-			break;
-	}
+    switch (id) {
+        case alliance:
+            rel.CreateAlliance();
+            break;
+        case tradeDeal:
+            break;
+        case peaceTreaty:
+            break;
+    }
 }
 
 void Request::Decline() {
-	switch (id) {
-		case alliance:
-			rel.WorsenRelations();
-			break;
-		case tradeDeal:
-			break;
-		case peaceTreaty:
-			break;
-		default:
-			break;
-	}
+    switch (id) {
+        case alliance:
+            rel.WorsenRelations();
+            break;
+        case tradeDeal:
+            break;
+        case peaceTreaty:
+            break;
+    }
 }
 
 Relation& Request::GetRelations() const {
@@ -166,11 +162,11 @@ void War::JoinWar(Country* newParticipant, Country* onTheSideOf) {
 	f.AddMember(newParticipant);
 }
 
-const std::set<Country*>& War::GetFaction(int i) const {
-	if (i != 0 && i != 1) {
-		throw std::runtime_error("Faction index out of bounds");
-	}
-	return factions[i].GetFaction();
+const std::set<Country*>& War::GetFaction(unsigned i) const {
+    if (i != 0 && i != 1) {
+        throw std::out_of_range("Faction index out of bounds");
+    }
+    return factions[i].GetFaction();
 }
 
 void War::AddClaim(Claim claim) {
@@ -183,11 +179,11 @@ void War::AddClaim(Claim claim) {
 	f.AddClaim(claim);
 }
 
-const std::vector<Claim>& War::GetClaims(int i) const {
-	if (i != 0 && i != 1) {
-		throw std::runtime_error("Faction index out of bounds");
-	}
-	return factions[i].GetClaims();
+const std::vector<Claim>& War::GetClaims(unsigned i) const {
+    if (i != 0 && i != 1) {
+        throw std::out_of_range("Faction index out of bounds");
+    }
+    return factions[i].GetClaims();
 }
 
 void War::AddScore(Country* instigator, int score) {

--- a/Diplomacy.h
+++ b/Diplomacy.h
@@ -58,10 +58,10 @@ public:
     
     bool GetIfTargetPairIsAtWar(const CountryPair& pair) const;
     void JoinWar(Country* newParticipant, Country* onTheSideOf);
-    const std::set<Country*>& GetFaction(int i) const;
+    const std::set<Country*>& GetFaction(unsigned i) const;
 
     void AddClaim(Claim claim);
-    const std::vector<Claim>& GetClaims(int i) const;
+    const std::vector<Claim>& GetClaims(unsigned i) const;
 
     void AddScore(Country* instigator, int score);
     int GetRelativeScore() const;
@@ -125,7 +125,7 @@ enum RequestType {
 
 class Request {
 public:
-    Request(RequestType id, int senderIndex, std::string senderTag, Relation& rel);
+    Request(RequestType id, unsigned senderIndex, std::string senderTag, Relation& rel);
 
     void Accept();
     void Decline();
@@ -136,7 +136,7 @@ public:
 
 private:
     RequestType id;
-    int index;
+    unsigned index;
     Relation &rel;
     std::string tag;
 

--- a/DiplomacyScreen.cpp
+++ b/DiplomacyScreen.cpp
@@ -50,7 +50,6 @@ DiplomacyScreen::DiplomacyScreen(MainWindow& mw, PlayerController* PC, unsigned 
 
 unsigned DiplomacyScreen::CreateCountryButtons(PlayerController* PC) {
     unsigned index = 0;
-    int flagsPerLine = 12;
     auto [Width, Height] = main_window->GetWindowDimensions();
 
     for(auto& country : PC->CountriesArr) {
@@ -65,7 +64,6 @@ unsigned DiplomacyScreen::CreateCountryButtons(PlayerController* PC) {
 
 unsigned DiplomacyScreen::CreateCountryButtons(PlayerController* PC, std::string targetTag) {
     unsigned index = 0;
-    int flagsPerLine = 12;
     auto [Width, Height] = main_window->GetWindowDimensions();
 
     for(auto& country : PC->CountriesArr) {

--- a/Drawable.cpp
+++ b/Drawable.cpp
@@ -56,7 +56,5 @@ void ApplyAnchor(SDL_Rect& rect, Anchor anchor) {
             rect.x -= rect.w;
             rect.y -= rect.h / 2;
             break;
-        default:
-            break;
     }
 }

--- a/Eater.h
+++ b/Eater.h
@@ -1,0 +1,17 @@
+#pragma once
+
+template <char... Chars>
+struct Eater {
+    inline friend std::istream& operator>>(std::istream& is, const Eater&) {
+        auto fail = [&](int wanted) {
+            if (is.peek() == wanted) {
+                is.ignore();
+                return false;
+            } else {
+                return true;
+            }
+        };
+        if ((... || fail(Chars))) is.setstate(std::ios::failbit);
+        return is;
+    }
+};

--- a/Factory.cpp
+++ b/Factory.cpp
@@ -1,7 +1,7 @@
 #include "Factory.h"
 
 void Factory::Tick() {
-	*(TargetStockpile) += materialsProduced + materialsNeeded;
+	*TargetStockpile += materialsProduced + materialsNeeded;
 }
 
 Factory::Factory(Stockpile* Target, Market* market, std::string arg, int c = 500) {
@@ -14,8 +14,8 @@ Factory::Factory(Stockpile* Target, Market* market, std::string arg, int c = 500
 
 Factory::~Factory() {
 	if (TargetMarket == nullptr) return;
-	(*TargetMarket).Demand += materialsNeeded;
-	(*TargetMarket).Supply -= materialsProduced;
+	TargetMarket->Demand += materialsNeeded;
+	TargetMarket->Supply -= materialsProduced;
 }
 
 void Factory::ChangeOwner(Stockpile* NewStockpile) {
@@ -24,8 +24,8 @@ void Factory::ChangeOwner(Stockpile* NewStockpile) {
 
 void Factory::confirmMaterials() {
 	if (TargetMarket == nullptr) return;
-	(*TargetMarket).Demand -= materialsNeeded;
-	(*TargetMarket).Supply += materialsProduced;
+	TargetMarket->Demand -= materialsNeeded;
+	TargetMarket->Supply += materialsProduced;
 }
 
 CanningFactory::CanningFactory(Stockpile* Target, Market* market) : Factory(Target, market, "canned food", 8000) {

--- a/Label.cpp
+++ b/Label.cpp
@@ -18,7 +18,7 @@ Label::Label(SDL_Renderer_ctx& r, std::string Text, int size, int x, int y, int 
 
 void Label::pDraw() {
     //Copy the text texture to the screen
-    SDL_RenderCopy(RendererReference, texture, NULL, &draw_rect);
+    SDL_RenderCopy(RendererReference, texture, nullptr, &draw_rect);
 }
 
 void Label::ChangeText(std::string Text) {
@@ -38,9 +38,10 @@ void Label::ChangeColor(Color rgb) {
     UpdateLabel();
 }
 
-void Label::ChangePosition(int x, int y) {
+void Label::ChangePosition(int X, int Y) {
     //Save the new Position
-    this->x = x, this->y = y;
+    x = X;
+    y = Y;
 
     //Setting the texture size
     int texW, texH;

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ TOBJ = $(SRC:%.cpp=build/%.tsan.o)
 CCMD = $(CXX) -std=c++20 -g $(SDLINCS) -c -o $@ $< -Wall -Wextra -Woverloaded-virtual -Werror -pedantic-errors $(OPTS)
 LCMD = $(CXX) -o $@ -std=c++20 -g $^ $(SDLLIBS) $(OPTS)
 
-CLANGOPTS = -Weverything -Wweak-vtables -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-documentation -Wno-poison-system-directories
+CLANGOPTS = -Weverything -Wweak-vtables -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-documentation -Wno-poison-system-directories -Wno-weak-vtables
 
 The_Great_War: $(OBJ)
 	$(LCMD)

--- a/MenuSettingsScreen.cpp
+++ b/MenuSettingsScreen.cpp
@@ -7,45 +7,46 @@
 #include <array>
 
 MenuSettingsScreen::MenuSettingsScreen(MainWindow& mw, std::function<void()> fp, std::function<void(std::unique_ptr<Screen>)> fpl) : BackScreen(mw, fp, fpl) {
-	SetupBg("Backgrounds/OldMenu.png");
+    SetupBg("Backgrounds/OldMenu.png");
     auto [Width, Height] = mw.GetWindowDimensions();
-	auto res = Resolutions::Resolution(mw.Width(), mw.Height());
-	currentResolutionIndex = Resolutions::findResolutionIndex(res);
 
-	AddDrawable<Button>(mw, int(Width * 0.75), int(Height * 0.85), int(Width * 0.08), int(Height * 0.06), "Apply", 32, [this] { ApplyChanges(); }, SDLK_RETURN);
-	AddDrawable<Button>(mw, int(Width * 0.85), int(Height * 0.85), int(Width * 0.08), int(Height * 0.06), "Back", 32, [this]{ Back(); }, SDLK_ESCAPE);
-	AddDrawable<Button>(mw, int(Width * 0.18), int(Height * 0.2), int(Width * 0.02), int(Height * 0.06), "<", 32, [this] {DecreaseResolution(); });
-	AddLabel<Label>(mw, res.toString() , int(Height / 33.75), int(Width * 0.25), int(Height * 0.23), center);
-	AddDrawable<Button>(mw, int(Width * 0.3), int(Height * 0.2), int(Width * 0.02), int(Height * 0.06), ">", 32, [this] {IncreaseResolution(); });
-	//AddDrawable<Checkbox>(mw, int(Width * 0.18), int(Height * 0.3), int(Height * 0.06), "VSync", 32);
+    auto res = Resolutions::Resolution(mw.Width(), mw.Height());
+    currentResolutionIndex = Resolutions::findResolutionIndex(res);
+
+    AddDrawable<Button>(mw, int(Width * 0.75), int(Height * 0.85), int(Width * 0.08), int(Height * 0.06), "Apply", 32, [this] { ApplyChanges(); }, SDLK_RETURN);
+    AddDrawable<Button>(mw, int(Width * 0.85), int(Height * 0.85), int(Width * 0.08), int(Height * 0.06), "Back", 32, [this]{ Back(); }, SDLK_ESCAPE);
+    AddDrawable<Button>(mw, int(Width * 0.18), int(Height * 0.2), int(Width * 0.02), int(Height * 0.06), "<", 32, [this] {DecreaseResolution(); });
+    AddLabel<Label>(mw, res.toString() , int(Height / 33.75), int(Width * 0.25), int(Height * 0.23), center);
+    AddDrawable<Button>(mw, int(Width * 0.3), int(Height * 0.2), int(Width * 0.02), int(Height * 0.06), ">", 32, [this] {IncreaseResolution(); });
+    //AddDrawable<Checkbox>(mw, int(Width * 0.18), int(Height * 0.3), int(Height * 0.06), "VSync", 32);
 }
 
 void MenuSettingsScreen::UpdateResolutionLabel() {
-	LabelArr[0]->ChangeText(Resolutions::SUPPORTED_RESOLUTIONS[currentResolutionIndex].toString());
+    LabelArr[0]->ChangeText(Resolutions::SUPPORTED_RESOLUTIONS[currentResolutionIndex].toString());
 }
 
 void MenuSettingsScreen::IncreaseResolution() {
-	if (currentResolutionIndex < Resolutions::SUPPORTED_RESOLUTIONS.size() - 1) {
-		currentResolutionIndex++;
-	}
+    if (currentResolutionIndex <= Resolutions::SUPPORTED_RESOLUTIONS.size()) {
+        currentResolutionIndex++;
+    }
 
-	UpdateResolutionLabel();
+    UpdateResolutionLabel();
 }
 
 void MenuSettingsScreen::DecreaseResolution() {
-	if (currentResolutionIndex > 0) {
-		currentResolutionIndex--;
-	}
+    if (currentResolutionIndex > 0) {
+        currentResolutionIndex--;
+    }
 
-	UpdateResolutionLabel();
+    UpdateResolutionLabel();
 }
 
 void MenuSettingsScreen::ApplyChanges() {
-	auto res = Resolutions::SUPPORTED_RESOLUTIONS[currentResolutionIndex];
-	SDL_SetWindowSize(main_window->window, res.GetWidth(), res.GetHeight());
-	//SDL_RenderSetVSync()
+    auto res = Resolutions::SUPPORTED_RESOLUTIONS[currentResolutionIndex];
+    SDL_SetWindowSize(main_window->window, res.GetWidth(), res.GetHeight());
+    //SDL_RenderSetVSync()
 
-	SDL_GetWindowSize(main_window->window, &main_window->windim.x, &main_window->windim.y);
+    SDL_GetWindowSize(main_window->window, &main_window->windim.x, &main_window->windim.y);
 
-	ChangeScreenFunc(std::make_unique<MenuSettingsScreen>(*main_window, QuitFunc, ChangeScreenFunc));
+    ChangeScreenFunc(std::make_unique<MenuSettingsScreen>(*main_window, QuitFunc, ChangeScreenFunc));
 }

--- a/MessageBox.cpp
+++ b/MessageBox.cpp
@@ -5,11 +5,11 @@
 #include "Label.h"
 #include "MainWindow.h"
 
-MessageBox::MessageBox(MainWindow& mw, std::string title, std::string message, std::function<void(void*)> f) {
+MessageBox::MessageBox(MainWindow& mw, std::string Title, std::string message, std::function<void(void*)> f) {
     auto [Width, Height] = mw.GetWindowDimensions();
 
     background = std::make_unique<Image>(mw, "Backgrounds/old_paper.png", int(Width * 0.3), int(Height * 0.3), int(Width * 0.4), int(Height * 0.4));
-    this->title = std::make_unique<Label>(mw, title, 42, int(Width * 0.5), int(Height * 0.34), int(Width * 0.35), center);
+    title = std::make_unique<Label>(mw, Title, 42, int(Width * 0.5), int(Height * 0.34), int(Width * 0.35), center);
     text = std::make_unique<Label>(mw, message, 32, int(Width * 0.5), int(Height * 0.37), int(Width * 0.35), center_top);
     okButton = std::make_unique<Button>(mw, int(Width * 0.67), int(Height * 0.66), int(Width * 0.09), int(Height * 0.055), "OK", 26, bottom_right, f, this, SDLK_RETURN);
 }

--- a/OpenFactoryScreen.cpp
+++ b/OpenFactoryScreen.cpp
@@ -6,7 +6,7 @@
 #include "MainWindow.h"
 #include "PlayerController.h"
 
-OpenFactoryScreen::OpenFactoryScreen(MainWindow& mw, int id, PlayerController* PC, std::function<void()> quitfunc) : Screen(mw, quitfunc){
+OpenFactoryScreen::OpenFactoryScreen(MainWindow& mw, unsigned id, PlayerController* PC, std::function<void()> quitfunc) : Screen(mw, quitfunc){
     PCref = PC;
     auto [Width, Height] = mw.GetWindowDimensions();
 
@@ -155,9 +155,9 @@ void OpenFactoryScreen::FactoryTypePlane(){
     FactoryType('v', F.cost);
 }
 
-void OpenFactoryScreen::FactoryType(char t, int cost){
+void OpenFactoryScreen::FactoryType(char t, int Cost){
     type = t;
-    std::string txt = "Factory cost: " + std::to_string(cost);
+    std::string txt = "Factory cost: " + std::to_string(Cost);
     LabelArr[2]->ChangeText(txt.c_str());
 }
 
@@ -232,7 +232,6 @@ void OpenFactoryScreen::BuildFactory(){
                 break;
         default:
                 return;
-                break;
     }
 
     if (PCref->CountriesArr.at(PCref->player_index)->Stock.Money >= NF->cost){

--- a/PlayerController.cpp
+++ b/PlayerController.cpp
@@ -16,7 +16,6 @@ namespace {
 struct Line {
     std::string str;
 
-    operator std::string& () { return str; }
     operator std::string const& () const { return str; }
 
     friend std::istream& operator>>(std::istream& is, Line& l) {
@@ -101,11 +100,11 @@ int PlayerController::LoadMap(void* pc){
         auto base = SDL_Surface_ctx::CreateRGBSurface(0, 16383, 2160, 32, 0, 0, 0, 0);
 
 	SDL_Rect strect = { .x = 232, .y = 0, .w = 5616 , .h = 2160 };
-	SDL_BlitSurface(PC.map, &strect, base, NULL);
+	SDL_BlitSurface(PC.map, &strect, base, nullptr);
 	strect = { .x = -5616 + 232, .y = 0, .w = 5616 * 2 , .h = 2160 };
-	SDL_BlitSurface(PC.map, &strect, base, NULL);
+	SDL_BlitSurface(PC.map, &strect, base, nullptr);
 	strect = { .x = -5616 * 2 + 232, .y = 0, .w = 5616 * 3 , .h = 2160 };
-	SDL_BlitSurface(PC.map, &strect, base, NULL);
+	SDL_BlitSurface(PC.map, &strect, base, nullptr);
 
 	PC.txt = SDL_Texture_ctx(PC.RendererReference, base);
 
@@ -140,7 +139,7 @@ void PlayerController::InitializeCountries(std::vector<std::string>& names, std:
 
 void PlayerController::InitializeStates(std::vector<std::string>& owners, std::vector<std::string>& names, std::vector<Coordinate>& coords, const std::vector<int>& populations, std::vector<Color>& colors){
 	short int res[8] = { 50, 50, 50, 50, 50, 50, 50, 50 };
-	int target = 0;
+	unsigned target = 0;
 
         StatesArr.reserve(populations.size());
 	for (unsigned x = 0; x < owners.size(); ++x) {
@@ -206,7 +205,7 @@ void PlayerController::Pause(){
 	if (Date.bIsPaused) {
 		Date.bIsPaused = false;
 		//Create a new thread that will be running the AdvanceDate function in parallel with everything else
-		thread = SDL_CreateThread(&PlayerController::AdvanceDate, NULL, this);
+		thread = SDL_CreateThread(&PlayerController::AdvanceDate, nullptr, this);
 	} else {
 		Date.bIsPaused = true;
 		//Wait until the date thread has stopped execution

--- a/PlayerController.h
+++ b/PlayerController.h
@@ -36,16 +36,16 @@ public:
 
     //Some info about the player
     std::string player_tag;
-    int player_index;
+    unsigned player_index;
 
     //The in-game date
     struct {
-            int Year;
-            int Month;
-            int Day;
-            int Speed;
-            bool bIsPaused;
-            int MonthDays[12];
+        int Year;
+        int Month;
+        int Day;
+        int Speed;
+        bool bIsPaused;
+        int MonthDays[12];
     } Date;
 
     //This is the representing the pass of a single day

--- a/Resolutions.cpp
+++ b/Resolutions.cpp
@@ -1,30 +1,26 @@
 #include "Resolutions.h"
 
-Resolutions::Resolution::Resolution(int width, int height) :
-	w(width), h(height) {
-}
+namespace Resolutions {
 
-std::string Resolutions::Resolution::toString() const {
-	return std::to_string(w) + "x" + std::to_string(h);
+std::string Resolution::toString() const {
+    return std::to_string(w) + 'x' + std::to_string(h);
 }
 
 int Resolutions::Resolution::GetWidth() const {
-	return w;
+    return w;
 }
 
 int Resolutions::Resolution::GetHeight() const {
-	return h;
+    return h;
 }
 
-bool Resolutions::Resolution::operator==(const Resolution& res) {
-	return w == res.w && h == res.h;
+unsigned findResolutionIndex(Resolutions::Resolution& res) {
+    for (unsigned i = 0; i < Resolutions::SUPPORTED_RESOLUTIONS.size(); i++) {
+        if (res == Resolutions::SUPPORTED_RESOLUTIONS[i]) {
+            return i;
+        }
+    }
+    return not_found;
 }
 
-int Resolutions::findResolutionIndex(Resolutions::Resolution& res) {
-	for (int i = 0; i < Resolutions::SUPPORTED_RESOLUTIONS.size(); i++) {
-		if (res == Resolutions::SUPPORTED_RESOLUTIONS[i]) {
-			return i;
-		}
-	}
-	return -1;
-}
+} // namespace Resolutions

--- a/Resolutions.h
+++ b/Resolutions.h
@@ -3,25 +3,27 @@
 #include <string>
 
 namespace Resolutions {
-	struct Resolution {
-	public:
-		Resolution(int width, int height);
 
-		std::string toString() const;
+    struct Resolution {
+    public:
+        constexpr Resolution(int width, int height) : w(width), h(height) {}
 
-		//Accessor functions
-		int GetWidth() const;
-		int GetHeight() const;
+        std::string toString() const;
 
-		bool operator == (const Resolution&);
+        //Accessor functions
+        int GetWidth() const;
+        int GetHeight() const;
 
-	private:
-		int w, h;
-	};
+        constexpr auto operator<=>(const Resolution&) const noexcept = default;
 
-	static const std::array<Resolution, 3> SUPPORTED_RESOLUTIONS = {Resolution(1280, 720), 
-																	Resolution(1920, 1080), 
-																	Resolution(2560, 1440)};
+    private:
+        int w, h;
+    };
 
-	int findResolutionIndex(Resolutions::Resolution&);
+    constexpr std::array<Resolution, 3> SUPPORTED_RESOLUTIONS = {Resolution(1280, 720),
+                                                                 Resolution(1920, 1080),
+                                                                 Resolution(2560, 1440)};
+
+    static inline constexpr unsigned not_found = static_cast<unsigned>(-1);
+    unsigned findResolutionIndex(Resolutions::Resolution&);
 }

--- a/Screen.cpp
+++ b/Screen.cpp
@@ -23,7 +23,7 @@ void Screen::RenderBackground() {
 	appropriate dimensions, based on the magnification
 	factor reiceived from user input*/
 	if (texture) {
-            SDL_RenderCopy(*main_window, texture, NULL, NULL);
+            SDL_RenderCopy(*main_window, texture, nullptr, nullptr);
         }
 }
 

--- a/ScreenList.h
+++ b/ScreenList.h
@@ -53,7 +53,7 @@ public:
 
     void ApplyChanges();
 private:
-    int currentResolutionIndex;
+    unsigned currentResolutionIndex;
 
     void UpdateResolutionLabel();
 };
@@ -161,6 +161,8 @@ public:
 
     PlayerController* PCref;
 
+    static inline constexpr unsigned flagsPerLine = 12;
+
 private:
     unsigned CreateCountryButtons(PlayerController* PC);
     unsigned CreateCountryButtons(PlayerController* PC, std::string targetTag);
@@ -176,7 +178,7 @@ private:
     void UpdateAllianceState();
     void UpdateEmbargoState();
 
-    int selectedCountryIndex;
+    unsigned selectedCountryIndex;
 };
 
 class IndustryScreen : public Screen {
@@ -209,7 +211,7 @@ public:
 
 class OpenFactoryScreen : public Screen {
 public:
-    OpenFactoryScreen(MainWindow& mw, int id, PlayerController* PC, std::function<void()> fp);
+    OpenFactoryScreen(MainWindow& mw, unsigned id, PlayerController* PC, std::function<void()> fp);
 
     void FactoryTypeLumber();
     void FactoryTypeGlass();
@@ -243,13 +245,13 @@ public:
     //Factory attributes
     int cost;
     PlayerController* PCref;
-    int index;
+    unsigned index;
     char type;
 };
 
 class StatePreview : public Screen {
 public:
-    StatePreview(MainWindow& mw, int id, std::string StateName, std::string controller, PlayerController* PC, int res[8], int pop, std::string Factories[4], std::function<void()> CloseFunc, std::function<void(std::unique_ptr<Screen>, std::string)> ChangeScreenFunc);
+    StatePreview(MainWindow& mw, unsigned id, std::string StateName, std::string controller, PlayerController* PC, int res[8], int pop, std::string Factories[4], std::function<void()> CloseFunc, std::function<void(std::unique_ptr<Screen>, std::string)> ChangeScreenFunc);
 
     void Render() override;
 
@@ -267,7 +269,7 @@ private:
 
     std::unique_ptr<OpenFactoryScreen> OFS;
 
-    int Id;
+    unsigned Id;
 
     PlayerController* PCref;
 };

--- a/State.cpp
+++ b/State.cpp
@@ -37,49 +37,49 @@ State::State(std::string name, int ID, std::string owner, std::string controller
 }
 
 void State::Tick(int TaxRate, int HealthCare){
-	State_Population += State_Population * (0.00005479452 / (1.0 + TaxRate / 200.0)) * (1 + HealthCare / 160.0);
+    State_Population += State_Population * (0.00005479452 / (1.0 + TaxRate / 200.0)) * (1 + HealthCare / 160.0);
 
-	TargetStockpile->Coal += Resources.Coal;
-	TargetStockpile->Oil += Resources.Oil;
-	TargetStockpile->Timber += Resources.Timber;
-	TargetStockpile->Rubber += Resources.Rubber;
-	TargetStockpile->Cotton += Resources.Cotton;
-	TargetStockpile->Iron += Resources.Iron;
-	TargetStockpile->Grain += Resources.Grain;
-	TargetStockpile->Fruit += Resources.Fruit;
+    TargetStockpile->Coal += Resources.Coal;
+    TargetStockpile->Oil += Resources.Oil;
+    TargetStockpile->Timber += Resources.Timber;
+    TargetStockpile->Rubber += Resources.Rubber;
+    TargetStockpile->Cotton += Resources.Cotton;
+    TargetStockpile->Iron += Resources.Iron;
+    TargetStockpile->Grain += Resources.Grain;
+    TargetStockpile->Fruit += Resources.Fruit;
 
-	for (int x = 0; x < 4; x++) {
-		if (State_Factories[x] != nullptr) {
-			State_Factories[x]->Tick();
-		}
-	}
+    for (unsigned x = 0; x < 4; x++) {
+        if (State_Factories[x] != nullptr) {
+            State_Factories[x]->Tick();
+        }
+    }
 }
 
 void State::ChangeController(std::string NewOwner, Stockpile* NewStock){
-	State_Controller = NewOwner;
-	TargetStockpile = NewStock;
-	for (int x = 0; x < 4; x++) {
-		if (State_Factories[x] != nullptr) {
-			State_Factories[x]->ChangeOwner(NewStock);
-		}
-	}
+    State_Controller = NewOwner;
+    TargetStockpile = NewStock;
+    for (unsigned x = 0; x < 4; x++) {
+        if (State_Factories[x] != nullptr) {
+            State_Factories[x]->ChangeOwner(NewStock);
+        }
+    }
 }
 
 int State::AddFactory(std::unique_ptr<Factory>& NewFactory){
-	for (int x = 0; x < 4; x++) {
-		if (State_Factories[x] == nullptr) {
-			State_Factories[x] = std::move(NewFactory);
-			return 0;
-		}
-	}
-	return -1;
+    for (unsigned x = 0; x < 4; x++) {
+        if (State_Factories[x] == nullptr) {
+            State_Factories[x] = std::move(NewFactory);
+            return 0;
+        }
+    }
+    return -1;
 }
 
-int State::RemoveFactory(int index){
-	if (State_Factories[index]) {
-		State_Factories[index] = nullptr;
+int State::RemoveFactory(unsigned index){
+    if (State_Factories[index]) {
+        State_Factories[index] = nullptr;
 
-		return 0;
-	}
-	return -1;
+        return 0;
+    }
+    return -1;
 }

--- a/State.h
+++ b/State.h
@@ -23,7 +23,7 @@ public:
 
     int AddFactory(std::unique_ptr<Factory>& NewFactory);
 
-    int RemoveFactory(int index);
+    int RemoveFactory(unsigned index);
 
     //This is the state's name
     std::string State_Name;

--- a/StatePreview.cpp
+++ b/StatePreview.cpp
@@ -5,7 +5,12 @@
 #include "Label.h"
 #include "Image.h"
 
-StatePreview::StatePreview(MainWindow& mw, int id, std::string StateName, std::string controller, PlayerController* PC, int res[8], int pop, std::string Factories[4], std::function<void()> CloseFunc, std::function<void(std::unique_ptr<Screen>, std::string)> ChangeScreenFunc) : Screen(mw) {
+StatePreview::StatePreview(MainWindow& mw, unsigned id, std::string StateName, std::string controller, PlayerController* PC, int res[8], int pop, std::string Factories[4],
+                           std::function<void()> CloseFunc, std::function<void(std::unique_ptr<Screen>, std::string)> changeScreenFunc) :
+    Screen(mw),
+    ChangeScreenFunc2(changeScreenFunc),
+    Id(id)
+{
         auto [Width, Height] = mw.GetWindowDimensions();
 	Controller = controller;
 	std::string str = "Flags/" + Controller;
@@ -40,8 +45,6 @@ StatePreview::StatePreview(MainWindow& mw, int id, std::string StateName, std::s
 	}
 
 	PCref = PC;
-	this->Id = id;
-	ChangeScreenFunc2 = ChangeScreenFunc;
 }
 
 void StatePreview::Render(){
@@ -93,10 +96,11 @@ void StatePreview::DeleteOFS(){
                 InputDrawableArr.resize(InputDrawableArrtop()-1);
 	}
 
-	int index = int(ImageArr.size()) - 1;
+        if(ImageArr.empty()) throw std::out_of_range("StatePreview::DeleteOFS ImageArr is empty");
+        auto index = ImageArr.size() - 1;
 	if (PCref->StatesArr[Id].State_Factories[index] != nullptr) {
 		std::string str = "Icons/Goods/" + PCref->StatesArr[Id].State_Factories[index]->Type + ".png";
-		AddImage<Image>(*main_window, str, int(Width * (0.055 + 0.0288 * index)), int(Height * 0.8999), 48, 48);
+		AddImage<Image>(*main_window, str, int(Width * (0.055L + 0.0288L * index)), int(Height * 0.8999), 48, 48);
 	}
 }
 

--- a/TextEntry.cpp
+++ b/TextEntry.cpp
@@ -5,27 +5,26 @@
 #include "MainWindow.h"
 
 #include <SDL.h>
-TextEntry::TextEntry(MainWindow& mw, int x, int y, int Width, int Height, std::string defaultText, int maxCharacters) : TextEntry(mw, x, y, Width, Height, top_left, defaultText, maxCharacters) {
+TextEntry::TextEntry(MainWindow& mw, int X, int Y, int Width, int Height, std::string defaultText, int maxCharacters) : TextEntry(mw, X, Y, Width, Height, top_left, defaultText, maxCharacters) {
 }
 
-TextEntry::TextEntry(MainWindow& mw, int x, int y, int Width, int Height, std::string defaultText, std::string hint, int maxCharacters) : TextEntry(mw, x, y, Width, Height, top_left, defaultText, hint, maxCharacters) {
+TextEntry::TextEntry(MainWindow& mw, int X, int Y, int Width, int Height, std::string defaultText, std::string Hint, int maxCharacters) : TextEntry(mw, X, Y, Width, Height, top_left, defaultText, Hint, maxCharacters) {
 }
 
-TextEntry::TextEntry(MainWindow& mw, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, int maxCharacters) : main_window(&mw) {
-    background = std::make_unique<Image>(mw, "Backgrounds/FlagBg.png", x, y, Width, Height, anchor);
-    textLabel = std::make_unique<Label>(mw, defaultText, 20, int(x * 1.08), int(y * 1.08), anchor);
-    hintLabel = NULL;
-
-    text = defaultText;
-    hint = "";
-    maxSize = maxCharacters;
-
-    this->x = x;
-    this->y = y;
+TextEntry::TextEntry(MainWindow& mw, int X, int Y, int Width, int Height, Anchor anchor, std::string defaultText, int maxCharacters) :
+    main_window(&mw),
+    x(X), y(Y),
+    text(defaultText),
+    maxSize(maxCharacters),
+    background(std::make_unique<Image>(mw, "Backgrounds/FlagBg.png", x, y, Width, Height, anchor)),
+    textLabel(std::make_unique<Label>(mw, defaultText, 20, int(x * 1.08), int(y * 1.08), anchor))
+{
 }
 
-TextEntry::TextEntry(MainWindow& mw, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, std::string hint, int maxCharacters) : TextEntry(mw, x, y, Width, Height, anchor, defaultText, maxCharacters) {
-    ChangeHint(hint);
+TextEntry::TextEntry(MainWindow& mw, int X, int Y, int Width, int Height, Anchor anchor, std::string defaultText, std::string Hint, int maxCharacters) :
+    TextEntry(mw, X, Y, Width, Height, anchor, defaultText, maxCharacters)
+{
+    ChangeHint(Hint);
 }
 
 void TextEntry::HandleInput(const SDL_Event& ev){
@@ -64,12 +63,12 @@ void TextEntry::HandleInput(const SDL_Event& ev){
     }
 }
 
-void TextEntry::ChangePosition(int x, int y, int Width, int Height){
-    background->ChangePosition(x, y, Width, Height);
-    textLabel->ChangePosition(int(x * 1.08), int(y * 1.08));
+void TextEntry::ChangePosition(int X, int Y, int Width, int Height){
+    background->ChangePosition(X, Y, Width, Height);
+    textLabel->ChangePosition(int(X * 1.08), int(Y * 1.08));
 
-    if (hintLabel != NULL) {
-        hintLabel->ChangePosition(int(x * 1.08), int(y * 1.08));
+    if (hintLabel) {
+        hintLabel->ChangePosition(int(X * 1.08), int(Y * 1.08));
     }
 }
 
@@ -81,24 +80,24 @@ std::string TextEntry::GetText(){
     return text;
 }
 
-void TextEntry::ChangeText(std::string text){
-    textLabel->ChangeText(text);
-    this->text = text;
+void TextEntry::ChangeText(std::string Text){
+    textLabel->ChangeText(Text);
+    text = Text;
 }
 
 std::string TextEntry::GetHint(){
     return hint;
 }
 
-void TextEntry::ChangeHint(std::string hint){
-    if (hint != this->hint) {
-        if (hintLabel != NULL) {
-            hintLabel->ChangeText(hint);
+void TextEntry::ChangeHint(std::string Hint){
+    if (Hint != hint) {
+        if (hintLabel) {
+            hintLabel->ChangeText(Hint);
         } else {
-            hintLabel = std::make_unique<Label>(*main_window, hint, 20, int(x * 1.08), int(y * 1.08));
+            hintLabel = std::make_unique<Label>(*main_window, Hint, 20, int(x * 1.08), int(y * 1.08));
         }
 
-        this->hint = hint;
+        hint = Hint;
     }
 }
 
@@ -107,7 +106,7 @@ void TextEntry::pDraw(){
 
     if (text != "") {
         textLabel->Draw();
-    } else if(hintLabel != NULL) {
+    } else if(hintLabel) {
         hintLabel->Draw();
     }
 }

--- a/TextEntry.h
+++ b/TextEntry.h
@@ -21,7 +21,7 @@ public:
     TextEntry(MainWindow& mw, int x, int y, int Width, int Height, Anchor anchor, std::string defaultText, std::string hint = "", int maxCharacters = 30);
 
     //Destructor
-    ~TextEntry() = default;
+    ~TextEntry() override = default;
 
     //Called when received input, to check whether the click was in this button
     void HandleInput(const SDL_Event& ev) override;
@@ -61,6 +61,7 @@ protected:
 
     //The components of the Entry
     std::unique_ptr<Image> background;
-    std::unique_ptr<Label> textLabel, hintLabel;
+    std::unique_ptr<Label> textLabel;
+    std::unique_ptr<Label> hintLabel;
 };
 #endif

--- a/ToggleButton.cpp
+++ b/ToggleButton.cpp
@@ -41,9 +41,9 @@ ToggleButton::~ToggleButton() {
 void ToggleButton::pDraw(){
     //Drawing the toggle button
     if (!value) {
-        SDL_RenderCopy(RendererReference, inactiveTexture, NULL, &draw_rect);
+        SDL_RenderCopy(RendererReference, inactiveTexture, nullptr, &draw_rect);
     } else {
-        SDL_RenderCopy(RendererReference, activeTexture, NULL, &draw_rect);
+        SDL_RenderCopy(RendererReference, activeTexture, nullptr, &draw_rect);
     }
 }
 

--- a/UI.cpp
+++ b/UI.cpp
@@ -46,7 +46,7 @@ void UI::Render(){
 	//Renders the country menu
 	flagbg->Draw();
 	flag->Draw();
-	for (int x = 0; x < 5; x++) {
+	for (unsigned x = 0; x < 5; x++) {
 		Buttons[x]->Draw();
 	}
 
@@ -58,7 +58,7 @@ void UI::Render(){
 	}
 	Date->Draw();
 	SpeedImg->Draw();
-	for (int x = 0; x < 2; x++) {
+	for (unsigned x = 0; x < 2; x++) {
 		DateButtons[x]->Draw();
 	}
 	PauseButton->Draw();
@@ -68,11 +68,11 @@ void UI::Handle_Input(SDL_Event& ev){
 	//Handles inputs for buttons
 	flag->HandleInput(ev);
 
-	for (int x = 0; x < 5; x++) {
+	for (unsigned x = 0; x < 5; x++) {
 		Buttons[x]->HandleInput(ev);
 	}
 
-	for (int x = 0; x < 2; x++) {
+	for (unsigned x = 0; x < 2; x++) {
 		DateButtons[x]->HandleInput(ev);
 	}
 


### PR DESCRIPTION
These are some of those I've started looking into: -Wcomma
-Wcovered-switch-default
-Wdouble-promotion
-Wimplicit-int-conversion
-Wimplicit-int-float-conversion
-Winconsistent-missing-destructor-override
-Wshadow
-Wshadow-field-in-constructor
-Wsign-conversion
-Wunreachable-code-break
-Wunused-const-variable
-Wunused-member-function
-Wzero-as-null-pointer-constant

There are a lot left to fix, especially
-Wsign-conversion
-Wweak-vtables