### PR TITLE
Use std::jthread

### DIFF
--- a/Checkbox.h
+++ b/Checkbox.h
@@ -15,7 +15,7 @@
 class Checkbox : public InputDrawable {
 public:
     // Constructor
-    Checkbox(MainWindow& mw, int x, int y, int Height, std::string text, int textSize, std::function<void(bool)> f = nullptr, int keybind = 0);
+    Checkbox(MainWindow& mw, int x, int y, int Height, std::string text, int textSize, std::function<void(bool)> f = {}, int keybind = 0);
     Checkbox(MainWindow& mw, int x, int y, int Height, std::string text, int textSize, Anchor anchor, std::function<void(bool)> f = nullptr, int keybind = 0);
 
     // Called when received input, to check whether the click was in this button

--- a/CountrySelection.cpp
+++ b/CountrySelection.cpp
@@ -14,6 +14,7 @@ const std::array<Color, CountrySelection::Countries> CountrySelection::colors{{{
 CountrySelection::CountrySelection(MainWindow& mw, std::function<void()> UnpauseF, std::function<void(std::unique_ptr<Screen>)> fpl) : Screen(mw, UnpauseF, fpl) {
     SetupBg("Backgrounds/CountrySelection.png");
     auto [Width, Height] = mw.GetWindowDimensions();
+
     int btnFontSize = int(Height / 33.75), nameFontSize = int(Height / 43.2);
 
     AddDrawable<Button>(

--- a/Eater.h
+++ b/Eater.h
@@ -29,7 +29,6 @@ struct Eater_impl {
             }
         };
         if((... || fail(Chars))) is.setstate(std::ios::failbit);
-
         return is;
     }
 };

--- a/GameScreen.cpp
+++ b/GameScreen.cpp
@@ -35,7 +35,7 @@ void GameScreen::Pause() {
             PM = std::make_unique<PauseMenu>(
                 *main_window, QuitFunc, [this] { Pause(); }, ChangeScreenFunc);
             bIsPaused = true;
-            if(PC->Date.bIsPaused == false) {
+            if(PC->bIsPaused == false) {
                 overlay->PauseDate(true);
             }
             overlay->Buttons[0]->Playsound();

--- a/MenuSettingsScreen.cpp
+++ b/MenuSettingsScreen.cpp
@@ -42,7 +42,7 @@ void MenuSettingsScreen::UpdateResolutionLabel() {
 }
 
 void MenuSettingsScreen::IncreaseResolution() {
-    if(currentResolutionIndex < Resolutions::SUPPORTED_RESOLUTIONS.size() - 1) {
+    if(currentResolutionIndex + 1 < Resolutions::SUPPORTED_RESOLUTIONS.size()) {
         currentResolutionIndex++;
     }
 

--- a/PlayerController.h
+++ b/PlayerController.h
@@ -13,8 +13,10 @@
 #include <SDL.h>
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <memory>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -32,8 +34,8 @@ private:
     void InitializeCountries(std::vector<std::string>& names, std::vector<std::string>& tags, const char* tag, const std::vector<Stockpile>& balance);
     void InitializeStates(std::vector<std::string>& owners, std::vector<std::string>& names, std::vector<Coordinate>& coords, const std::vector<int>& populations, std::vector<Color>& colors);
 
-    static int LoadMap(void*);
-    static int LoadUtilityAssets(void*);
+    void LoadMap();
+    void LoadUtilityAssets();
 
 public:
     MainWindow* main_window;
@@ -48,15 +50,16 @@ public:
         int Month;
         int Day;
         int Speed;
-        bool bIsPaused;
         int MonthDays[12];
     } Date;
+
+    std::atomic<bool> bIsPaused{true};
 
     // This is the representing the pass of a single day
     void Tick();
 
     // Advances the date by one day
-    static int AdvanceDate(void* ref);
+    void AdvanceDate();
 
     // Pauses the flow of time
     void Pause();
@@ -83,6 +86,6 @@ public:
     SDL_Surface_ctx provinces;
 
     // Used to run the time-functionality of the game
-    SDL_Thread* thread;
+    std::jthread thread;
 };
 #endif

--- a/Slider.cpp
+++ b/Slider.cpp
@@ -11,14 +11,10 @@ Slider::Slider(MainWindow& mw, int x, int y, int Width, int Height, int minvalue
 
 Slider::Slider(MainWindow& mw, int x, int y, int Width, int Height, Anchor anchor, int minvalue, int maxvalue, int value, std::function<void()> OnSliderValueChanged) :
     InputDrawable(anchor), main_window(&mw), Marker(SDL_Texture_ctx::IMG_Load(mw, "Drawable/Slider/Circle.png")) {
-    std::cout << "Slider " << this << '\n';
     // Initialize all variables
     ChangeValues(minvalue, maxvalue, value);
     ChangePosition(x, y, Width, Height);
     onSliderValueChanged = OnSliderValueChanged;
-}
-Slider::~Slider() {
-    std::cout << "~Slider " << this << '\n';
 }
 
 void Slider::SetActive(bool state) {

--- a/Slider.h
+++ b/Slider.h
@@ -15,7 +15,6 @@ public:
     // Constructor, initializes the values
     Slider(MainWindow& mw, int x, int y, int Width, int Height, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
     Slider(MainWindow& mw, int x, int y, int Width, int Height, Anchor anchor, int minvalue = 0, int maxvalue = 100, int value = -1, std::function<void()> onSliderValueChanged = {});
-    ~Slider() override;
 
     // Handle input events
     void HandleInput(const SDL_Event& ev) override;


### PR DESCRIPTION
There are currently three extra threads started by the application. None do synchronization between the threads so there are race conditions.

I've replaced the threads with `std::jthread`s which can be used to start a thread in a member function (unlike `SDL_CreateThread`).

`bIsPaused` is made into a `std::atomic<bool>` and moved out of the `Date` struct.

No further synchronization work has been done - but it's needed.